### PR TITLE
Port/neptune 0.16

### DIFF
--- a/xnt-core/src/api/regtest/regtest_impl.rs
+++ b/xnt-core/src/api/regtest/regtest_impl.rs
@@ -4,6 +4,7 @@ use super::error::RegTestError;
 use crate::api::export::Timestamp;
 use crate::protocol::consensus::block::mock_block_generator::MockBlockGenerator;
 use crate::protocol::consensus::block::Block;
+use crate::protocol::consensus::consensus_rule_set::ConsensusRuleSet;
 use crate::protocol::shared::SIZE_20MB_IN_BYTES;
 use crate::state::mining::block_proposal::BlockProposal;
 use crate::state::wallet::expected_utxo::ExpectedUtxo;
@@ -148,6 +149,7 @@ impl RegTestPrivate {
         // retrieve selected tx from mempool for block inclusion.
         let txs_from_mempool = if include_mempool_txs {
             gs.mempool.get_transactions_for_block_composition(
+                ConsensusRuleSet::infer_from(gsl.cli().network, next_block_height),
                 SIZE_20MB_IN_BYTES,
                 Some(gsl.cli().max_num_compose_mergers.get()),
             )

--- a/xnt-core/src/api/tx_initiation/error.rs
+++ b/xnt-core/src/api/tx_initiation/error.rs
@@ -7,6 +7,7 @@ use crate::api::export::NativeCurrencyAmount;
 use crate::api::export::RecordTransactionError;
 use crate::application::job_queue::errors::AddJobError;
 use crate::application::job_queue::errors::JobHandleError;
+use crate::protocol::consensus::consensus_rule_set::TransactionTooBig;
 use crate::protocol::consensus::transaction::transaction_proof::TransactionProofType;
 use crate::protocol::proof_abstractions::tasm::prover_job::ProverJobError;
 use crate::state::transaction::tx_proving_capability::TxProvingCapability;
@@ -128,4 +129,7 @@ pub enum SendError {
         tip_digest: Digest,
         max: usize,
     },
+
+    #[error("transaction can never be mined: {0}")]
+    TooBig(#[from] TransactionTooBig),
 }

--- a/xnt-core/src/api/tx_initiation/initiator.rs
+++ b/xnt-core/src/api/tx_initiation/initiator.rs
@@ -207,6 +207,28 @@ impl TransactionInitiator {
         // may have been checked before, but just in case.
         self.worker().check_rate_limit().await?;
 
+        // Refuse to broadcast a transaction that can never be mined: peers
+        // reject it on admission and it would only occupy our own mempool.
+        {
+            let kernel = &tx.transaction.kernel;
+            let network = self.global_state_lock.cli().network;
+            let next_block_height = self
+                .global_state_lock
+                .lock_guard()
+                .await
+                .chain
+                .light_state()
+                .header()
+                .height
+                .next();
+
+            ConsensusRuleSet::infer_from(network, next_block_height).mempool_size_check(
+                kernel.inputs.len(),
+                kernel.outputs.len(),
+                kernel.announcements.len(),
+            )?;
+        }
+
         // note: acquires write-lock.
         // note: tx is validated internally.
         self.global_state_lock.record_own_transaction(tx).await?;

--- a/xnt-core/src/application/config/data_directory.rs
+++ b/xnt-core/src/application/config/data_directory.rs
@@ -56,7 +56,17 @@ impl DataDirectory {
 
     /// Create directory if it does not exist
     pub async fn create_dir_if_not_exists(dir: &Path) -> Result<()> {
-        tokio::fs::create_dir_all(dir)
+        let mut dir_builder = tokio::fs::DirBuilder::new();
+        dir_builder.recursive(true);
+
+        // The data directory holds wallet secrets and credentials, so deny
+        // other users any access. Directories that already exist keep their
+        // permissions.
+        #[cfg(unix)]
+        dir_builder.mode(0o700);
+
+        dir_builder
+            .create(dir)
             .await
             .with_context(|| format!("Failed to create data directory {}", dir.display()))
     }

--- a/xnt-core/src/application/database/storage/storage_schema/simple_rusty_storage.rs
+++ b/xnt-core/src/application/database/storage/storage_schema/simple_rusty_storage.rs
@@ -23,23 +23,26 @@ pub struct SimpleRustyStorage {
 impl StorageWriter for SimpleRustyStorage {
     #[inline]
     async fn persist(&mut self) {
-        let mut write_ops = WriteBatchAsync::new();
+        // Hold the lock across the entire operation, so that no interleaved
+        // write can land between building the batch and clearing the queue.
+        let mut pending_writes = self.schema.pending_writes.lock_guard_mut().await;
 
-        // note: we read all pending ops and perform mutations
-        // in a single atomic operation.
-        {
-            let mut pending_writes = self.schema.pending_writes.lock_guard_mut().await;
-            for op in &pending_writes.write_ops {
-                match op.clone() {
-                    WriteOperation::Write(key, value) => write_ops.op_write(key, value),
-                    WriteOperation::Delete(key) => write_ops.op_delete(key),
-                }
+        let mut write_ops = WriteBatchAsync::new();
+        for op in &pending_writes.write_ops {
+            match op.clone() {
+                WriteOperation::Write(key, value) => write_ops.op_write(key, value),
+                WriteOperation::Delete(key) => write_ops.op_delete(key),
             }
-            pending_writes.write_ops.clear();
-            pending_writes.persist_count += 1;
         }
 
-        self.db.batch_write(write_ops).await
+        self.db.batch_write(write_ops).await;
+
+        // Only clear the queue once the batch write has completed. If this
+        // future is dropped mid-write, the operations stay queued and the next
+        // persist retries them. Redoing an operation is harmless: writes and
+        // deletes are both idempotent.
+        pending_writes.write_ops.clear();
+        pending_writes.persist_count += 1;
     }
 
     async fn drop_unpersisted(&mut self) {

--- a/xnt-core/src/application/json_rpc/core/api/rpc.rs
+++ b/xnt-core/src/application/json_rpc/core/api/rpc.rs
@@ -23,6 +23,9 @@ pub enum RestoreMembershipProofError {
 
     #[error("Exceeds the allowed limit")]
     ExceedsAllowed,
+
+    #[error("A new tip arrived while the membership proofs were being derived")]
+    TipMoved,
 }
 
 #[derive(Debug, Clone, Copy, Error, Eq, PartialEq, Serialize, Deserialize)]
@@ -67,6 +70,9 @@ pub enum RpcError {
     #[error("Failed to submit block: {0}")]
     SubmitBlock(SubmitBlockError),
 
+    #[error("Too many absolute index sets requested: maximum is {max}, got {got}")]
+    TooManyAbsoluteIndexSets { max: usize, got: usize },
+
     // Common case errors
     #[error("Invalid address provided in arguments")]
     InvalidAddress,
@@ -79,6 +85,15 @@ pub enum RpcError {
 }
 
 pub type RpcResult<T> = Result<T, RpcError>;
+
+/// The hard limit on how many membership proofs one request may ask for.
+/// Applies to every caller, including those allowed to exceed
+/// [`MAX_RESTRICTED_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS`].
+pub const MAX_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS: usize = 1000;
+
+/// The limit on how many membership proofs one request may ask for, for
+/// callers that are not granted unrestricted access.
+pub const MAX_RESTRICTED_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS: usize = 256;
 
 #[async_trait]
 pub trait RpcApi: Sync + Send {

--- a/xnt-core/src/application/json_rpc/server/service.rs
+++ b/xnt-core/src/application/json_rpc/server/service.rs
@@ -36,6 +36,16 @@ use crate::state::wallet::address::KeyType;
 use crate::state::wallet::change_policy::ChangePolicy;
 use crate::state::wallet::utxo_notification::UtxoNotificationMedium;
 
+/// How many membership proofs are derived per acquisition of the state lock.
+/// Deriving one reads from disk, and the lock blocks the application of new
+/// tips, so the derivations of a request are spread over several acquisitions.
+const RESTORE_MEMBERSHIP_PROOF_CHUNK_SIZE: usize = 16;
+
+/// How many times membership-proof derivation is restarted when a new tip
+/// arrives while it is running. Every proof in a response must be relative to
+/// the same mutator set, so a new tip invalidates the proofs derived so far.
+const RESTORE_MEMBERSHIP_PROOF_MAX_ATTEMPTS: usize = 3;
+
 #[async_trait]
 impl RpcApi for RpcServer {
     async fn network_call(&self, _: NetworkRequest) -> RpcResult<NetworkResponse> {
@@ -585,40 +595,84 @@ impl RpcApi for RpcServer {
         &self,
         request: RestoreMembershipProofRequest,
     ) -> RpcResult<RestoreMembershipProofResponse> {
-        if request.absolute_index_sets.len() > 256 && !self.unrestricted {
+        let got = request.absolute_index_sets.len();
+        if got > MAX_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS {
+            return Err(RpcError::TooManyAbsoluteIndexSets {
+                max: MAX_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS,
+                got,
+            });
+        }
+        if got > MAX_RESTRICTED_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS && !self.unrestricted {
             return Err(RpcError::RestoreMembershipProof(
                 RestoreMembershipProofError::ExceedsAllowed,
             ));
         }
 
-        let state = self.state.lock_guard().await;
-        let ams = state.chain.archival_state().archival_mutator_set.ams();
-        let mut membership_proofs = Vec::with_capacity(request.absolute_index_sets.len());
+        // Ensure the read lock is not held too long: do derivation in chunks.
+        // All authentication paths in the response must be relative to the same
+        // mutator set. So verify that tip does not move in between chunks.
+        for _ in 0..RESTORE_MEMBERSHIP_PROOF_MAX_ATTEMPTS {
+            let (tip_hash, tip_height, tip_mutator_set) = {
+                let state = self.state.lock_guard().await;
+                let current_tip = state.chain.light_state();
+                (
+                    current_tip.hash(),
+                    current_tip.header().height,
+                    current_tip
+                        .mutator_set_accumulator_after()
+                        .expect("Tip must have valid MSA after"),
+                )
+            };
 
-        for (index, set) in request.absolute_index_sets.into_iter().enumerate() {
-            match ams.restore_membership_proof_privacy_preserving(set).await {
-                Ok(msmp) => membership_proofs.push(msmp.into()),
-                Err(err) => {
-                    debug!("Failed to restore MSMP for {index}: {err}");
-                    return Err(RpcError::RestoreMembershipProof(
-                        RestoreMembershipProofError::Failed(index),
-                    ));
+            let mut membership_proofs = Vec::with_capacity(got);
+            let mut tip_moved = false;
+
+            for (j, index_sets) in request
+                .absolute_index_sets
+                .chunks(RESTORE_MEMBERSHIP_PROOF_CHUNK_SIZE)
+                .enumerate()
+            {
+                let state = self.state.lock_guard().await;
+                if state.chain.light_state().hash() != tip_hash {
+                    tip_moved = true;
+                    break;
+                }
+
+                let ams = state.chain.archival_state().archival_mutator_set.ams();
+                for (offset, index_set) in index_sets.iter().enumerate() {
+                    match ams
+                        .restore_membership_proof_privacy_preserving(*index_set)
+                        .await
+                    {
+                        Ok(msmp) => membership_proofs.push(msmp.into()),
+                        Err(err) => {
+                            let index = j * RESTORE_MEMBERSHIP_PROOF_CHUNK_SIZE + offset;
+                            debug!("Failed to restore MSMP for {index}: {err}");
+                            return Err(RpcError::RestoreMembershipProof(
+                                RestoreMembershipProofError::Failed(index),
+                            ));
+                        }
+                    }
                 }
             }
+
+            if tip_moved {
+                continue;
+            }
+
+            let snapshot = RpcMsMembershipSnapshot {
+                synced_height: tip_height.into(),
+                synced_hash: tip_hash,
+                membership_proofs,
+                synced_mutator_set: (&tip_mutator_set).into(),
+            };
+
+            return Ok(RestoreMembershipProofResponse { snapshot });
         }
 
-        let current_tip = state.chain.light_state();
-        let tip_mutator_set = current_tip
-            .mutator_set_accumulator_after()
-            .expect("Tip must have valid MSA after");
-        let snapshot = RpcMsMembershipSnapshot {
-            synced_height: current_tip.header().height.into(),
-            synced_hash: current_tip.hash(),
-            membership_proofs,
-            synced_mutator_set: (&tip_mutator_set).into(),
-        };
-
-        Ok(RestoreMembershipProofResponse { snapshot })
+        Err(RpcError::RestoreMembershipProof(
+            RestoreMembershipProofError::TipMoved,
+        ))
     }
 
     async fn submit_transaction_call(
@@ -1462,6 +1516,34 @@ pub mod tests {
             BlockHeight::genesis(),
             rpc_server.height().await.unwrap().height
         );
+    }
+
+    #[apply(shared_tokio_runtime)]
+    async fn restore_membership_proof_rejects_too_many_index_sets() {
+        use crate::application::json_rpc::core::api::rpc::MAX_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS;
+        use crate::util_types::mutator_set::removal_record::absolute_index_set::AbsoluteIndexSet;
+        use crate::util_types::mutator_set::shared::NUM_TRIALS;
+
+        let absolute_index_set = AbsoluteIndexSet::new([0_u128; NUM_TRIALS as usize]);
+        let got = MAX_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS + 1;
+
+        for unrestricted in [false, true] {
+            let mut rpc_server = test_rpc_server().await;
+            rpc_server.unrestricted = unrestricted;
+
+            let err = rpc_server
+                .restore_membership_proof(vec![absolute_index_set; got])
+                .await
+                .unwrap_err();
+
+            assert_eq!(
+                RpcError::TooManyAbsoluteIndexSets {
+                    max: MAX_RESTORE_MEMBERSHIP_PROOF_INDEX_SETS,
+                    got
+                },
+                err
+            );
+        }
     }
 
     #[test_strategy::proptest(async = "tokio", cases = 5)]

--- a/xnt-core/src/application/loops/main_loop.rs
+++ b/xnt-core/src/application/loops/main_loop.rs
@@ -884,7 +884,11 @@ impl MainLoopHandler {
                         }
                     }
 
-                    let mut update_jobs: Vec<MempoolUpdateJob> = vec![];
+                    // Track the "update" jobs that should be performed after a
+                    // new tip is set. Keyed by transaction ID, so that multiple
+                    // incoming blocks do not schedule the same mempool
+                    // transaction to be updated more than once.
+                    let mut update_jobs: HashMap<_, _> = HashMap::new();
                     for new_block in blocks {
                         debug!(
                             "Storing block {:x} in database. Height: {}, Mined: {}",
@@ -904,12 +908,16 @@ impl MainLoopHandler {
 
                         let update_jobs_ = global_state_mut.set_new_tip(new_block).await?;
 
-                        update_jobs.extend(update_jobs_);
+                        update_jobs.extend(
+                            update_jobs_
+                                .into_iter()
+                                .map(|update_job| (update_job.txid(), update_job)),
+                        );
                     }
 
                     global_state_mut.flush_databases().await?;
 
-                    update_jobs
+                    update_jobs.into_values().collect_vec()
                 };
 
                 // Inform all peers about new block

--- a/xnt-core/src/application/loops/main_loop.rs
+++ b/xnt-core/src/application/loops/main_loop.rs
@@ -469,7 +469,7 @@ impl MainLoopHandler {
     ///
     /// Sends the result back through the provided channel.
     async fn update_mempool_jobs(
-        mut global_state_lock: GlobalStateLock,
+        global_state_lock: GlobalStateLock,
         update_jobs: Vec<MempoolUpdateJob>,
         job_queue: Arc<TritonVmJobQueue>,
         transaction_update_sender: mpsc::Sender<Vec<MempoolUpdateJobResult>>,
@@ -489,10 +489,10 @@ impl MainLoopHandler {
 
                     // Acquire lock, and drop it immediately.
                     let msa_update = global_state_lock
-                        .lock_guard_mut()
+                        .lock_guard()
                         .await
                         .chain
-                        .archival_state_mut()
+                        .archival_state()
                         .get_mutator_set_update_to_tip(
                             old_msa,
                             SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,
@@ -541,7 +541,7 @@ impl MainLoopHandler {
                 } => {
                     let upgrade_incentive = UpgradeIncentive::Critical;
                     let Ok(update_job) = global_state_lock
-                        .lock_guard_mut()
+                        .lock_guard()
                         .await
                         .update_single_proof_job(
                             old_kernel.to_owned(),
@@ -1523,7 +1523,7 @@ impl MainLoopHandler {
         // Check if it's time to run the proof-upgrader, and if we're capable
         // of upgrading a transaction proof.
         let upgrade_candidate = {
-            let mut global_state = self.global_state_lock.lock_guard_mut().await;
+            let global_state = self.global_state_lock.lock_guard().await;
             if !attempt_upgrade(&global_state, main_loop_state) {
                 trace!("Not attempting upgrade.");
                 return Ok(());
@@ -1532,8 +1532,7 @@ impl MainLoopHandler {
             debug!("Attempting to run transaction-proof-upgrade");
 
             // Find a candidate for proof upgrade
-            let Some(upgrade_candidate) = get_upgrade_task_from_mempool(&mut global_state).await
-            else {
+            let Some(upgrade_candidate) = get_upgrade_task_from_mempool(&global_state).await else {
                 debug!("Found no transaction-proof to upgrade");
                 return Ok(());
             };

--- a/xnt-core/src/application/loops/main_loop.rs
+++ b/xnt-core/src/application/loops/main_loop.rs
@@ -1500,7 +1500,11 @@ impl MainLoopHandler {
                 .proof_upgrader_task
                 .as_ref()
                 .is_some_and(|x| !x.is_finished());
+            let vm_job_queue = vm_job_queue();
+            let busy = vm_job_queue.num_queued_jobs() > 0;
+
             global_state.cli().tx_proof_upgrading
+                && !busy
                 && global_state.net.sync_anchor.is_none()
                 && global_state.proving_capability() == TxProvingCapability::SingleProof
                 && !previous_upgrade_task_is_still_running
@@ -1565,12 +1569,24 @@ impl MainLoopHandler {
         main_loop_state: &mut MutableMainLoopState,
         update_jobs: Vec<MempoolUpdateJob>,
     ) {
-        // job completion of the spawned task is communicated through the
-        // `update_mempool_txs_handle` channel.
         let vm_job_queue = vm_job_queue();
-        if let Some(handle) = main_loop_state.update_mempool_txs_handle.as_ref() {
+        let num_queued_job = vm_job_queue.num_queued_jobs();
+
+        // Don't do anything if there are already too many jobs in the queue.
+        // A later block will hopefully update the transaction in question, or
+        // the current-running job will self correct.
+        if num_queued_job > 2 {
+            warn!(
+                "Not updating mempool txs since job queue \
+                   already contains {num_queued_job} jobs"
+            );
+            return;
+        }
+
+        if let Some(handle) = main_loop_state.update_mempool_txs_handle.take() {
             handle.abort();
         }
+
         let (update_sender, update_receiver) =
             mpsc::channel::<Vec<MempoolUpdateJobResult>>(TX_UPDATER_CHANNEL_CAPACITY);
 

--- a/xnt-core/src/application/loops/main_loop.rs
+++ b/xnt-core/src/application/loops/main_loop.rs
@@ -2202,7 +2202,7 @@ mod tests {
     ) -> TestSetup {
         const CHANNEL_CAPACITY_MINER_TO_MAIN: usize = 10;
 
-        let network = Network::Main;
+        let network = cli.network;
         let (
             main_to_peer_tx,
             main_to_peer_rx,
@@ -2622,6 +2622,11 @@ mod tests {
             let num_outgoing_connections = 0;
             let num_incoming_connections = 0;
 
+            // Use a network whose premine funds the devnet wallet; on mainnet
+            // this fork's premine leaves the test wallet without funds. Not
+            // RegTest: that network mocks proofs, and the merge performed by
+            // the upgrade under test requires real single proofs as input.
+            let network = Network::Testnet(0);
             let TestSetup {
                 mut main_loop_handler,
                 mut main_to_peer_rx,
@@ -2629,7 +2634,7 @@ mod tests {
             } = setup(
                 num_outgoing_connections,
                 num_incoming_connections,
-                cli_args::Args::default(),
+                cli_args::Args::default_with_network(network),
             )
             .await;
 
@@ -2638,7 +2643,7 @@ mod tests {
             let mocked_cli = cli_args::Args {
                 tx_proving_capability: Some(TxProvingCapability::SingleProof),
                 tx_proof_upgrading: true,
-                ..Default::default()
+                ..cli_args::Args::default_with_network(network)
             };
 
             main_loop_handler

--- a/xnt-core/src/application/loops/main_loop.rs
+++ b/xnt-core/src/application/loops/main_loop.rs
@@ -870,6 +870,17 @@ impl MainLoopHandler {
                     // Ask miner to stop work until state update is completed
                     self.main_to_miner_tx.send(MainToMiner::WaitForContinue);
 
+                    // Register sync progress on the healthy (canonical) path
+                    // too. The global synchronization timeout measures time
+                    // since the anchor was last updated; without this refresh
+                    // it fires a fixed 480 s after sync-mode entry no matter
+                    // how well the sync is going, and the forced re-entry gap
+                    // pushes catch-up onto the unbounded fork-reconciliation
+                    // path.
+                    if let Some(sync_anchor) = global_state_mut.net.sync_anchor.as_mut() {
+                        sync_anchor.catch_up(last_block.header().height, last_block.hash());
+                    }
+
                     // Get out of sync mode if needed
                     if global_state_mut.net.sync_anchor.is_some() {
                         let stay_in_sync_mode = stay_in_sync_mode(

--- a/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -1045,7 +1045,9 @@ mod tests {
     #[traced_test]
     #[apply(shared_tokio_runtime)]
     async fn dont_upgrade_foreign_proof_collection_if_fee_too_low() {
-        let network = Network::Main;
+        // Use a network whose premine funds the devnet wallet; on mainnet
+        // this fork's premine leaves the test wallet without funds.
+        let network = Network::RegTest;
 
         // Alice is premine recipient, so she can make a transaction (after
         // expiry of timelock). Rando is not premine recipient.

--- a/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -450,7 +450,7 @@ impl UpgradeJob {
             /* Perform upgrade */
             // No locks may be held here!
             let offchain_notifications = global_state_lock.cli().fee_notification;
-            let (upgraded, expected_utxos) = match upgrade_job
+            let (upgraded, gobbler_expected_utxo) = match upgrade_job
                 .clone()
                 .upgrade(
                     triton_vm_job_queue.clone(),
@@ -461,12 +461,12 @@ impl UpgradeJob {
                 )
                 .await
             {
-                Ok((upgraded_tx, expected_utxos)) => {
+                Ok((upgraded_tx, expected_utxo)) => {
                     info!(
                         "Successfully upgraded transaction {}",
                         upgraded_tx.kernel.txid()
                     );
-                    (upgraded_tx, expected_utxos)
+                    (upgraded_tx, expected_utxo)
                 }
                 Err(e) => {
                     error!(
@@ -495,12 +495,17 @@ impl UpgradeJob {
             /* Check if upgrade resulted in valid transaction */
             upgrade_job = {
                 let mut global_state = global_state_lock.lock_guard_mut().await;
+                // Notify wallet of gobbler UTXO
+                global_state
+                    .wallet_state
+                    .add_expected_utxos(gobbler_expected_utxo)
+                    .await;
+
                 let tip_mutator_set = global_state
                     .chain
                     .light_state()
                     .mutator_set_accumulator_after()
                     .expect("Block from state must have mutator set after");
-
                 let transaction_is_up_to_date =
                     upgraded.kernel.mutator_set_hash == tip_mutator_set.hash();
 
@@ -524,11 +529,6 @@ impl UpgradeJob {
                     // sure to have it when they ask.
                     global_state
                         .mempool_insert(upgraded.clone(), upgrade_incentive.into(), AddReason::Upgraded)
-                        .await;
-
-                    global_state
-                        .wallet_state
-                        .add_expected_utxos(expected_utxos)
                         .await;
                     drop(global_state); // sooner is better.
 
@@ -642,6 +642,9 @@ impl UpgradeJob {
 
     /// Build a single-proof backed gobbler transaction that can be used to
     /// charge another transaction for upgrading a proof.
+    ///
+    /// Returns the transaction and the to-be-expected UTXO if node uses
+    /// off-chain fee notificaitons.
     #[expect(clippy::too_many_arguments)]
     async fn build_gobbler(
         gobbling_fee: NativeCurrencyAmount,
@@ -652,7 +655,7 @@ impl UpgradeJob {
         fee_notification_policy: FeeNotificationPolicy,
         mutator_set: MutatorSetAccumulator,
         old_tx_timestamp: Timestamp,
-    ) -> anyhow::Result<(Transaction, Vec<ExpectedUtxo>)> {
+    ) -> anyhow::Result<(Transaction, Option<ExpectedUtxo>)> {
         info!("Producing gobbler-transaction for a value of {gobbling_fee}");
         let (utxo_notification_method, receiver_preimage) =
             Self::gobbler_notification_method_with_receiver_preimage(
@@ -671,12 +674,17 @@ impl UpgradeJob {
 
         let gobbler_witness = gobbler.primitive_witness();
 
-        let expected_utxos = if fee_notification_policy == FeeNotificationPolicy::OffChain {
+        let expected_utxo = if fee_notification_policy == FeeNotificationPolicy::OffChain {
             gobbler
                 .tx_outputs
                 .expected_utxos(UtxoNotifier::FeeGobbler, receiver_preimage)
         } else {
             vec![]
+        };
+        let expected_utxo = match expected_utxo.len() {
+            0 => None,
+            1 => Some(expected_utxo[0].clone()),
+            _ => panic!("Fee gobbler can maximum create one known output"),
         };
 
         // ensure that proof-type is SingleProof
@@ -703,17 +711,18 @@ impl UpgradeJob {
             proof,
         };
 
-        Ok((gobbler_tx, expected_utxos))
+        Ok((gobbler_tx, expected_utxo))
     }
 
     /// Execute the proof upgrade.
     ///
     /// Upgrades transactions to a proof of higher quality that is more likely
     /// to be picked up by a miner. Returns the upgraded proof, or an error if
-    /// the prover is already in use and the proof_job_options is set to not wait if
-    /// prover is busy.
+    /// the prover is already in use and the proof_job_options is set to not
+    /// wait if prover is busy.
     ///
-    /// Charges a fee for the upgrade task if this is desirable.
+    /// Charges a fee for the upgrade task if this is desirable, and returns
+    /// the to-be-expected UTXO associated with this fee.
     pub(crate) async fn upgrade(
         self,
         triton_vm_job_queue: Arc<TritonVmJobQueue>,
@@ -721,15 +730,15 @@ impl UpgradeJob {
         own_wallet_entropy: &WalletEntropy,
         current_block_height: BlockHeight,
         fee_notification_policy: FeeNotificationPolicy,
-    ) -> anyhow::Result<(Transaction, Vec<ExpectedUtxo>)> {
+    ) -> anyhow::Result<(Transaction, Option<ExpectedUtxo>)> {
         let gobbling_fee = self.gobbling_fee();
         let mutator_set = self.mutator_set();
         let old_tx_timestamp = self.old_tx_timestamp();
         let network = proof_job_options.job_settings.network;
         let consensus_rule_set = ConsensusRuleSet::infer_from(network, current_block_height);
 
-        let (maybe_gobbler, expected_utxos) = if gobbling_fee.is_positive() {
-            let (gobbler, eutxos) = Self::build_gobbler(
+        let (maybe_gobbler, gobbler_expected_utxo) = if gobbling_fee.is_positive() {
+            let (gobbler, gobbler_eutxo) = Self::build_gobbler(
                 gobbling_fee,
                 triton_vm_job_queue.clone(),
                 proof_job_options.clone(),
@@ -741,9 +750,9 @@ impl UpgradeJob {
             )
             .await?;
 
-            (Some(gobbler), eutxos)
+            (Some(gobbler), gobbler_eutxo)
         } else {
-            (None, vec![])
+            (None, None)
         };
 
         let mut rng: StdRng =
@@ -790,7 +799,7 @@ impl UpgradeJob {
                     upgraded_tx
                 };
 
-                Ok((tx, expected_utxos))
+                Ok((tx, gobbler_expected_utxo))
             }
             UpgradeJob::Merge {
                 left_kernel,
@@ -834,13 +843,13 @@ impl UpgradeJob {
                     info!("Proof-upgrader merging with gobbler: Done");
                 };
 
-                Ok((ret, expected_utxos))
+                Ok((ret, gobbler_expected_utxo))
             }
             UpgradeJob::PrimitiveWitnessToProofCollection(pw_to_pc) => Ok((
                 pw_to_pc
                     .upgrade(triton_vm_job_queue.clone(), &proof_job_options)
                     .await?,
-                expected_utxos,
+                gobbler_expected_utxo,
             )),
             UpgradeJob::PrimitiveWitnessToSingleProof(pw_to_sp) => Ok((
                 pw_to_sp
@@ -850,13 +859,13 @@ impl UpgradeJob {
                         consensus_rule_set,
                     )
                     .await?,
-                expected_utxos,
+                gobbler_expected_utxo,
             )),
             UpgradeJob::UpdateMutatorSetData(update_job) => {
                 let ret = update_job
                     .upgrade(triton_vm_job_queue, proof_job_options)
                     .await?;
-                Ok((ret, expected_utxos))
+                Ok((ret, gobbler_expected_utxo))
             }
         }
     }

--- a/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -544,7 +544,7 @@ impl UpgradeJob {
 
                 let Some(ms_update) = global_state
                     .chain
-                    .archival_state_mut()
+                    .archival_state()
                     .get_mutator_set_update_to_tip(
                         &mutator_set_for_tx,
                         SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,
@@ -855,7 +855,7 @@ impl UpgradeJob {
 /// of this job to the wallet of this node. The value reported will be zero for
 /// all 3rd party transactions.
 pub(super) async fn get_upgrade_task_from_mempool(
-    global_state: &mut GlobalState,
+    global_state: &GlobalState,
 ) -> Option<UpgradeJob> {
     let tip_mutator_set = global_state
         .chain
@@ -1061,9 +1061,9 @@ mod tests {
                 .await;
             assert!(
                 !upgrade_priority.is_irrelevant()
-                    && get_upgrade_task_from_mempool(&mut rando).await.is_some()
+                    && get_upgrade_task_from_mempool(&rando).await.is_some()
                     || upgrade_priority.is_irrelevant()
-                        && get_upgrade_task_from_mempool(&mut rando).await.is_none()
+                        && get_upgrade_task_from_mempool(&rando).await.is_none()
             );
 
             // A high-fee paying transaction must be returned for upgrading
@@ -1078,7 +1078,7 @@ mod tests {
             rando
                 .mempool_insert(pc_tx_high_fee.clone().into(), UpgradePriority::Irrelevant, AddReason::Submitted)
                 .await;
-            let job = get_upgrade_task_from_mempool(&mut rando).await.unwrap();
+            let job = get_upgrade_task_from_mempool(&rando).await.unwrap();
             let UpgradeJob::ProofCollectionToSingleProof(ProofCollectionToSingleProof {
                 kernel,
                 ..
@@ -1336,8 +1336,8 @@ mod tests {
         }
 
         let merge_upgrade_job = {
-            let mut alice = alice.lock_guard_mut().await;
-            get_upgrade_task_from_mempool(&mut alice).await.unwrap()
+            let alice = alice.lock_guard().await;
+            get_upgrade_task_from_mempool(&alice).await.unwrap()
         };
         assert!(
             matches!(merge_upgrade_job, UpgradeJob::Merge { .. }),

--- a/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -469,13 +469,25 @@ impl UpgradeJob {
                     (upgraded_tx, expected_utxos)
                 }
                 Err(e) => {
-                    error!("UpgradeProof job failed. error: {e}");
+                    error!(
+                        "UpgradeProof job failed for transaction(s) {}. error: {e}",
+                        affected_txids.iter().join("; ")
+                    );
                     error!(
                         "Consider lowering your proving capability to {}, in case it is set higher.\nCurrent proving \
                         capability is set to: {}.",
                         TxProvingCapability::ProofCollection,
                         global_state_lock.cli().proving_capability()
                     );
+
+                    // Pass over these transactions until the next block, so
+                    // that one job that cannot succeed does not keep every
+                    // other candidate from being upgraded.
+                    global_state_lock
+                        .lock_guard_mut()
+                        .await
+                        .mempool_record_upgrade_failure(affected_txids);
+
                     return;
                 }
             };

--- a/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/xnt-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -959,7 +959,7 @@ pub(super) async fn get_upgrade_task_from_mempool(
         .collect_vec();
     jobs.sort_by_key(|job| job.upgrade_incentive());
 
-    jobs.first().cloned()
+    jobs.last().cloned()
 }
 
 #[cfg(test)]

--- a/xnt-core/src/application/loops/mine_loop.rs
+++ b/xnt-core/src/application/loops/mine_loop.rs
@@ -553,7 +553,7 @@ pub(crate) async fn create_block_transaction_from(
         info!("No synced single-proof tx found for merge looking for one to update");
         let min_gobbling_fee = NativeCurrencyAmount::zero();
         let update_job = global_state_lock
-            .lock_guard_mut()
+            .lock_guard()
             .await
             .preferred_update_job_from_mempool(min_gobbling_fee, TxUpgradeFilter::match_all())
             .await;

--- a/xnt-core/src/application/loops/mine_loop.rs
+++ b/xnt-core/src/application/loops/mine_loop.rs
@@ -534,6 +534,7 @@ pub(crate) async fn create_block_transaction_from(
             .await
             .mempool
             .get_transactions_for_block_composition(
+                consensus_rule_set,
                 block_capacity_for_transactions,
                 Some(max_num_mergers),
             ),
@@ -613,6 +614,7 @@ pub(crate) async fn create_block_transaction_from(
                 .await
                 .mempool
                 .get_transactions_for_block_composition(
+                    consensus_rule_set,
                     block_capacity_for_transactions,
                     Some(max_num_mergers),
                 ),
@@ -1281,7 +1283,7 @@ pub(crate) mod tests {
                 .lock_guard_mut()
                 .await
                 .mempool
-                .get_transactions_for_block_composition(SIZE_20MB_IN_BYTES, None)
+                .get_transactions_for_block_composition(ConsensusRuleSet::default(), SIZE_20MB_IN_BYTES, None)
                 .is_empty(),
             "May not have synced tx in mempool"
         );

--- a/xnt-core/src/application/loops/peer_loop.rs
+++ b/xnt-core/src/application/loops/peer_loop.rs
@@ -1442,13 +1442,21 @@ impl PeerLoopHandler {
                             );
                             match removal_record_error_code {
                                 Ok(_) => unreachable!(),
-                                Err(RemovalRecordValidityError::AbsentAuthenticatedChunk) => {
-                                    debug!("invalid because membership proof is missing");
+                                Err(RemovalRecordValidityError::MismatchedChunkIndices) => {
+                                    debug!(
+                                        "invalid because the authenticated chunks are not the ones the \
+                                         indices require: some are missing or superfluous"
+                                    );
                                 }
                                 Err(RemovalRecordValidityError::InvalidSwbfiMmrMp {
                                     chunk_index,
                                 }) => {
                                     debug!("invalid because membership proof for chunk index {chunk_index} is invalid");
+                                }
+                                Err(RemovalRecordValidityError::DuplicateChunkIndex {
+                                    chunk_index,
+                                }) => {
+                                    debug!("invalid because chunk index {chunk_index} occurs more than once");
                                 }
                             };
                             self.punish(NegativePeerSanction::UnconfirmableTransaction)

--- a/xnt-core/src/application/loops/peer_loop.rs
+++ b/xnt-core/src/application/loops/peer_loop.rs
@@ -657,6 +657,7 @@ impl PeerLoopHandler {
                 if peers.len() > MAX_PEER_LIST_LENGTH {
                     self.punish(NegativePeerSanction::FloodPeerListResponse)
                         .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
                 }
 
                 let peers = peers

--- a/xnt-core/src/application/loops/peer_loop.rs
+++ b/xnt-core/src/application/loops/peer_loop.rs
@@ -1352,10 +1352,29 @@ impl PeerLoopHandler {
                     )
                 };
 
-                // 1. If transaction is invalid, punish.
                 let network = self.global_state_lock.cli().network;
                 let consensus_rule_set =
                     ConsensusRuleSet::infer_from(network, current_block_height);
+
+                // 0. If transaction can never be mined, punish. Checked before
+                // validity because it reads only kernel lengths, whereas
+                // validity verifies proofs.
+                if let Err(too_big) = consensus_rule_set.mempool_size_check(
+                    transaction.kernel.inputs.len(),
+                    transaction.kernel.outputs.len(),
+                    transaction.kernel.announcements.len(),
+                ) {
+                    warn!(
+                        "Received transaction with TXID {} that exceeds the allowed limits, and \
+                         can therefore never be mined: {too_big}",
+                        transaction.kernel.txid()
+                    );
+                    self.punish(NegativePeerSanction::UnrelayableTransaction)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                }
+
+                // 1. If transaction is invalid, punish.
                 if !transaction.is_valid(network, consensus_rule_set).await {
                     warn!("Received invalid tx");
                     self.punish(NegativePeerSanction::InvalidTransaction)

--- a/xnt-core/src/application/rpc/auth.rs
+++ b/xnt-core/src/application/rpc/auth.rs
@@ -139,7 +139,12 @@ impl Cookie {
         path_tmp.set_extension(extension);
 
         if let Some(parent_dir) = path.parent() {
-            tokio::fs::create_dir_all(&parent_dir)
+            let mut dir_builder = tokio::fs::DirBuilder::new();
+            dir_builder.recursive(true);
+            #[cfg(unix)]
+            dir_builder.mode(0o700);
+            dir_builder
+                .create(&parent_dir)
                 .await
                 .map_err(|e| error::CookieFileError {
                     path: path.clone(),
@@ -151,10 +156,15 @@ impl Cookie {
         }
 
         // open new temp file
-        let mut file = tokio::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
+        //
+        // The cookie is a credential as powerful as the wallet file, so it
+        // gets the same protection the wallet file has.
+        let mut open_options = tokio::fs::OpenOptions::new();
+        open_options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        open_options.mode(0o600);
+
+        let mut file = open_options
             .open(&path_tmp)
             .await
             .map_err(|e| error::CookieFileError {
@@ -320,6 +330,30 @@ mod tests {
         use std::collections::HashSet;
 
         use super::*;
+
+        #[cfg(unix)]
+        #[apply(shared_tokio_runtime)]
+        pub async fn cookie_is_inaccessible_to_other_users() -> anyhow::Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let data_dir = unit_test_data_directory(Network::Main)?;
+            Cookie::try_new(&data_dir).await?;
+
+            let cookie_file_path = Cookie::cookie_file_path(&data_dir);
+            let cookie_mode = tokio::fs::metadata(&cookie_file_path)
+                .await?
+                .permissions()
+                .mode();
+            assert_eq!(0o600, cookie_mode & 0o777);
+
+            let cookie_dir_mode = tokio::fs::metadata(cookie_file_path.parent().unwrap())
+                .await?
+                .permissions()
+                .mode();
+            assert_eq!(0o700, cookie_dir_mode & 0o777);
+
+            Ok(())
+        }
 
         /// tests cookies are unique
         ///

--- a/xnt-core/src/application/rpc/server.rs
+++ b/xnt-core/src/application/rpc/server.rs
@@ -3234,7 +3234,7 @@ impl RPC for NeptuneRPCServer {
     }
 
     async fn upgrade(
-        mut self,
+        self,
         _ctx: context::Context,
         token: auth::Token,
         tx_kernel_id: TransactionKernelId,
@@ -3270,7 +3270,7 @@ impl RPC for NeptuneRPCServer {
                 let gobbling_potential = NativeCurrencyAmount::zero();
                 let update_job = self
                     .state
-                    .lock_guard_mut()
+                    .lock_guard()
                     .await
                     .update_single_proof_job(
                         tx.kernel,
@@ -3287,7 +3287,7 @@ impl RPC for NeptuneRPCServer {
                 let gobbling_potential = NativeCurrencyAmount::zero();
                 let raise_job = self
                     .state
-                    .lock_guard_mut()
+                    .lock_guard()
                     .await
                     .upgrade_proof_collection_job(
                         tx.kernel,

--- a/xnt-core/src/lib.rs
+++ b/xnt-core/src/lib.rs
@@ -134,6 +134,19 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<MainLoopHandler> {
     let mut global_state_lock =
         GlobalStateLock::from_global_state(global_state, rpc_server_to_main_tx.clone());
 
+    // Ensure archival state is consistent. Repairs the block MMR and mutator
+    // set if a previous run was killed after writing a block but before
+    // finishing the rest of the tip update.
+    //
+    // `archival_state_mut` panics on a light node, so the call must be guarded.
+    {
+        let mut state = global_state_lock.lock_guard_mut().await;
+        if state.chain.is_archival_node() {
+            info!("Checking archival state consistency");
+            state.chain.archival_state_mut().recover().await?;
+        }
+    }
+
     // Construct the broadcast channel to communicate from the main task to peer tasks
     let (main_to_peer_broadcast_tx, _main_to_peer_broadcast_rx) =
         broadcast::channel::<MainToPeerTask>(PEER_CHANNEL_CAPACITY);

--- a/xnt-core/src/protocol/consensus/block/mod.rs
+++ b/xnt-core/src/protocol/consensus/block/mod.rs
@@ -74,6 +74,7 @@ use crate::protocol::proof_abstractions::timestamp::Timestamp;
 use crate::protocol::proof_abstractions::verifier::verify;
 use crate::protocol::proof_abstractions::SecretWitness;
 use crate::state::wallet::address::ReceivingAddress;
+use crate::state::wallet::wallet_entropy::WalletEntropy;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
 use crate::util_types::mutator_set::commit;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
@@ -434,7 +435,7 @@ impl Block {
     }
 
     pub fn genesis(network: Network) -> Self {
-        let premine_distribution = Self::premine_distribution();
+        let premine_distribution = Self::premine_distribution(network);
         let total_premine_amount = premine_distribution
             .iter()
             .map(|(_receiving_address, amount)| *amount)
@@ -444,7 +445,7 @@ impl Block {
         let mut genesis_mutator_set = MutatorSetAccumulator::default();
         let mut genesis_tx_outputs = vec![];
         for ((receiving_address, _amount), utxo) in
-            premine_distribution.iter().zip(Self::premine_utxos())
+            premine_distribution.iter().zip(Self::premine_utxos(network))
         {
             let utxo_digest = Tip5::hash(&utxo);
             // generate randomness for mutator set commitment
@@ -496,7 +497,35 @@ impl Block {
         Digest::new(bfe_array![u64::from(network.id()), 0, 0, 0, 0])
     }
 
-    fn original_premine_distribution() -> Vec<(ReceivingAddress, NativeCurrencyAmount)> {
+    /// The premine allocation for `network`.
+    ///
+    /// Mainnet's allocation is hardcoded in
+    /// [`Self::mainnet_premine_distribution`] and must never change: the genesis
+    /// block it produces is pinned to the live chain (see
+    /// [`Self::premine_utxos`]).
+    ///
+    /// Every other network additionally funds the devnet wallet. Upstream
+    /// allocated to that wallet the same way; this fork dropped it when it set
+    /// its own mainnet premine, which left every test needing spendable funds
+    /// unable to build a transaction. Because the addition is gated on the
+    /// network, mainnet's distribution — and therefore its genesis hash — is
+    /// unaffected.
+    fn original_premine_distribution(
+        network: Network,
+    ) -> Vec<(ReceivingAddress, NativeCurrencyAmount)> {
+        let mut distribution = Self::mainnet_premine_distribution();
+
+        if network != Network::Main {
+            let devnet_address = WalletEntropy::devnet_wallet()
+                .nth_generation_spending_key(0)
+                .to_address();
+            distribution.push((devnet_address.into(), NativeCurrencyAmount::coins(20)));
+        }
+
+        distribution
+    }
+
+    fn mainnet_premine_distribution() -> Vec<(ReceivingAddress, NativeCurrencyAmount)> {
         // The premine UTXOs can be hardcoded here.
         vec![
             (ReceivingAddress::from_bech32m("xntnwm19tgyejh6wxmjqn09shm044d2kfrr3vygk2hzpey739qw4uw6npsgwlagxanu4ndp94x9y6vcnfz8tcwrhcgk0sfxr7z8g78w47lv758edaxa80pjj8sgshdtjgp8jtp5rpxy0ds3c23h2xvecst4e8yevr7cx6t9llczdudwqejwjklpjqy8369v0eydxzh6awmxw2t6clrvtck0guzgjfz8ata54l3zhfrkqrncmynz856tugjkau6f6jh5wxu783vn8wzl0jv5v5s5vecuengvq0hsprj2cp4j323wxxdl95l5x88g0ww5mzjf3tlxdr2md5jvqncxyu3gj5ezvyd6dqex6g45fz7znfgz0kjdtxdsyzkernax5de5v0uhe97dydktttvwymy7kehznzzutv3gdtxmk805kqlthy42hgcnsfxxpktujqlkeftsvht24uuhjqgv45khpuwt0p26rkg30sd2dvgd4k2mu05rzjnathyqw748qm792gtd39vupxe4h3wdzap4rhkdescvjhsh3k6rpcp49vkhpk5722vwadg39844609ku79s4j25uqyr99fk4zf3u4uffm6hk5pgqax903gm0pn5utgngr90ef9kzzpdp6acwv574t8hyf9sdt6de8vlx8t3hu3e0yzvy6hrsxwrpjr296z4wtpulgazxsphw4hn6k7zhu9ehmdknhudl0xf6dzj0uz8yaxw4sju9sthmsc2uju07ua0amu0jvpfqqtsqkeyrjj8vgxssaqk35w40ze7dhpvgcqxehm8xccfxn6m9j707kcwfr5quyze2ntxmqfdw4n5yg93rzdrmskh9hsdut9s9u3d4zm2dk8pfl85394twy9g89c8ncarcealz4dhjc6vdw0gmm9rfce0t959e8fx2hczzhhpp6trufk8vm3r2ck3e6dyuuzgqh0jzfd9r9l2zyaf7mnz4cqyer34zgfpufg4683pgw9h4vr3f825m6gled0g5nz92u7eaelgdm5wkpg4dzmrqhl8hszelq4h2aglcgynn3y6xfrsyplfvfhmd9s68rdagqaa20gh2tnc4hpev9uuqvz99vcfahelyraz9xq9gucpkgv99w2wrca066p8j7qcdlljd5nq8yau76man3989c0kq0ulzs7e2079w8v3q6dnaynr8y286kfmm85z6sg2n0eqm7dlep3ml38pemyh9n40zydk98dlmz9f8c5ppsxeglvy4davsqfu5ll7q7ufzhy7xfvgcz7sm9akkl7gkcsad08w48el8keusussuk8upnc0gs7aq9kz2znl7uyc77wupyry9zwne86pnnsp8v496kfdx3nwkkpc89md5eh9ph55xvs6gnz05wqkvlkc4ztpqcc37d4nee5fhpuwxkvlvyq29u0lqe9j3dfhtdru9k0l7vm56wq4ed27w80puylx4w5agnf54v8hnv5vs36dxjw8xklsvsqsk4dlv3un9dn2sr6tj7aknuvhd8et6anhfvxjmfjqzth53gvt6hvys5gu8hhaqzavyta475yzflx882zqqadm3htl07qawfwylkf8apju9cc8xd9uzcfzs0mhhfw4qhn9qhrv09clgn6rl8l4rr5cemtmvsy9gsel9qvpa4ysd5upe3kas2vu5fk0fgw5wzjs0u27yexe2m6e8ysn426vl0v4ejclryse2u2dupzp73kzmz42pqa49xxgukzr4mw7e9rkqtulgzw47l44zspw453hd0q7dllach6ws0ym4j4qs7yexn05xpfe8nz0e29xe2ra93dyn2q8ca49mezgdmh9cd8k0shg4ztwxcu6pmkaxrf7kfmzn8wrfmxthnz9t6gn6e2ym58fdyu9ln4qfl7me2vtg465c94sgrgehc8qhrmqr7x7vjrfe2s648kuhulhhhsvf5plqmff8evj3y3g33ds4klzd42y02v53r2cfkqnjkrwrme8w27svzkwg4lpt7r0jvcn7klwmpstufgkf5c9pdhewyuvxuhjfsvp6n62vnxkup3t8m0z94twyprxp5sd3pla02j0kj76pu6928st26vp06kqv7assrugejn8jn9lt3eemapqmrunsfyy0yhh42tgmrlfht63vys0vzjg97jau7truzuycct2rtx7a8zqjuwyu82v3qmz99ddcucg0zxckpslaayknwpplyz9yma8pzk8dsx70qj0s3q5waj8whxxctsf7gh5z07sadhh042yeuz4qrpmmpcnafnvlcnv0sswq66a97gaqxtm4wuxsvl082dltvwtqsrzw285vfc97aewvg8pkh26u40cuxm7qxvg7c5anzhwhphl5m28jul3clvgzl5cth8awccmcyfl0ze9lzykcwpuasmcf080ynp437h57gtajwawayaclnmgjc7fp5477mzctm4m8d2ay2t3r4jzgmpf97dlckhfjlsrxfpr7ckv7kt3j4w4rmv3z9p2tdcs6slq6nrx543g6eqd3afyk4cu74xfjklnj0ny968v4zegprw7ncrmut0jzcvmknwtfxl9fmpwhnzdn4059r29zlaqwhrwfwzx3e4envdl8zer6zsh6qkejj3445pycsg95a7t5vh0t498q5zcdxvuzyk3xzs3y5upnxyc53k962pk4cfur5cn4f8varemgny86qpknhvkdjxwafxjwvue2mgu8zymv7x99e9wqqcq23tzm8n3skv9a4k9rpw0r27fevs4tqku7q3uh77g7yw206tugdavd327t9wk2zytw9prfdzeuf6dkvywcg9pmkchrf6azwhc3483f5z03pjy2rglhy7w2z0tuc4jr9njzk28hq8rkrggd8uc6whry8am30j2yt4ez4e8z8amcm2pyvcxd7g5acq63dlk4s465ug28ryvfvagjxaxvjc77fgkl5mseg0y68mmf7vpmlysjp5d3qgpjfcpy7dgws2gjvct9qflqw5ms36czcv7ls3c32jmpnn9mrev4h2k89k2qctr4ye599a5s76z0utup69zsxcqklr5jn6pp5uf39r3w75danrvdc2mrmxncykm9y8ka57yzkyfyrvft4mvtzr86eys0qnrwegs2st2u8gjextz4kvk66whp2ncytm5t2ftnq20a7vu222k93r6n82lt2lrp6akrxknc2a66tg5pycu9rck3v8h5jfm4xul0wa4htzjxehtder9c4usudechyqx4qv3r4tj7cl3sczja6l63uh7j4nvzselnspc9udjf3dh5ljld9m60lem3fyrvt7dnew0va7g9tgg4544g2yfpmnxrqztm8632vayv674c8yxn2yhvlsm043d5nyvk99fpht5yr6y8nw9qs5y7hxtnnrasy7chtuwqu5shd3qgjc2hpgvjm6kdzkxxpsfdlypw4tldu5", Network::Main).unwrap(), NativeCurrencyAmount::coins(1942384))
@@ -504,11 +533,11 @@ impl Block {
     }
 
     /// All premine allocations, including claims fund and claims
-    fn premine_distribution() -> Vec<(ReceivingAddress, NativeCurrencyAmount)> {
-        [Self::original_premine_distribution()].concat()
+    fn premine_distribution(network: Network) -> Vec<(ReceivingAddress, NativeCurrencyAmount)> {
+        [Self::original_premine_distribution(network)].concat()
     }
 
-    pub fn premine_utxos() -> Vec<Utxo> {
+    pub fn premine_utxos(network: Network) -> Vec<Utxo> {
         // Premine will be unlocked at genesis.
         //
         // The native-currency type-script hash is pinned to the launch-era value
@@ -520,7 +549,7 @@ impl Block {
         let nc_hash = NativeCurrency::legacy_type_script_hash();
 
         let mut utxos = vec![];
-        for (receiving_address, amount) in Self::premine_distribution() {
+        for (receiving_address, amount) in Self::premine_distribution(network) {
             let coins = vec![
                 Coin::new_native_currency_with_type_script_hash(nc_hash, amount),
                 //TimeLock::until(premine_release_date),
@@ -2309,7 +2338,58 @@ pub(crate) mod tests {
 
     #[test]
     fn premine_distribution_does_not_crash() {
-        Block::premine_distribution();
+        Block::premine_distribution(Network::Main);
+    }
+
+    /// Mainnet's genesis block is pinned to the live chain: if this hash moves,
+    /// every node on mainnet stops agreeing with this build. Nothing that
+    /// touches the premine, the genesis transaction, or the native-currency
+    /// type-script hash may change it.
+    ///
+    /// Recorded 2026-08-12, before adding the devnet-wallet premine for
+    /// non-mainnet networks.
+    #[test]
+    fn mainnet_genesis_hash_is_pinned() {
+        assert_eq!(
+            "03176465667522202772,04681390879739058532,17582005166685872536,\
+             11472275972434987608,03744294643659606529"
+                .replace([' ', '\\'], ""),
+            Block::genesis(Network::Main).hash().to_string(),
+            "mainnet genesis hash must never change"
+        );
+    }
+
+    /// Only mainnet gets the hardcoded allocation; every other network also
+    /// funds the devnet wallet that the test suite spends from.
+    #[test]
+    fn only_non_mainnet_networks_fund_the_devnet_wallet() {
+        assert_eq!(
+            1,
+            Block::premine_distribution(Network::Main).len(),
+            "mainnet premine must hold exactly the hardcoded allocation"
+        );
+
+        let devnet_lock_script_hash = ReceivingAddress::from(
+            WalletEntropy::devnet_wallet()
+                .nth_generation_spending_key(0)
+                .to_address(),
+        )
+        .lock_script_hash();
+
+        for network in [
+            Network::TestnetMock,
+            Network::RegTest,
+            Network::Testnet(0),
+        ] {
+            let utxos = Block::premine_utxos(network);
+            assert_eq!(2, utxos.len(), "{network} premine must fund the devnet wallet");
+            assert!(
+                utxos
+                    .iter()
+                    .any(|utxo| utxo.lock_script_hash() == devnet_lock_script_hash),
+                "{network} premine must contain the devnet wallet's UTXO"
+            );
+        }
     }
 
     /// Exhibits a strategy for creating one transaction by merging in many

--- a/xnt-core/src/protocol/consensus/block/mutator_set_update.rs
+++ b/xnt-core/src/protocol/consensus/block/mutator_set_update.rs
@@ -187,43 +187,35 @@ impl MutatorSetUpdate {
         authenticated_items: &mut [&mut AuthenticatedItem],
     ) -> bool {
         let mut cloned_removals = self.removals.clone();
-        let mut remaining_removal_records = cloned_removals.iter_mut().rev().collect::<Vec<_>>();
-        for addition_record in &self.additions {
-            RemovalRecord::batch_update_from_addition(
-                &mut remaining_removal_records,
-                ms_accumulator,
-            );
+        {
+            let mut own_removal_records = cloned_removals.iter_mut().collect::<Vec<_>>();
+            for addition_record in &self.additions {
+                RemovalRecord::batch_update_from_addition(&mut own_removal_records, ms_accumulator);
 
-            RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
+                RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
 
-            AuthenticatedItem::batch_update_from_addition(
-                authenticated_items,
-                ms_accumulator,
-                *addition_record,
-            );
+                AuthenticatedItem::batch_update_from_addition(
+                    authenticated_items,
+                    ms_accumulator,
+                    *addition_record,
+                );
 
-            ms_accumulator.add(addition_record);
-        }
-
-        let mut removal_records_are_valid = true;
-        while let Some(applied_removal_record) = remaining_removal_records.pop() {
-            RemovalRecord::batch_update_from_remove(
-                &mut remaining_removal_records,
-                applied_removal_record,
-            );
-
-            RemovalRecord::batch_update_from_remove(removal_records, applied_removal_record);
-
-            AuthenticatedItem::batch_update_from_remove(
-                authenticated_items,
-                applied_removal_record,
-            );
-
-            if !ms_accumulator.can_remove(applied_removal_record) {
-                removal_records_are_valid = false;
+                ms_accumulator.add(addition_record);
             }
-            ms_accumulator.remove(applied_removal_record);
         }
+
+        let removal_records_are_valid = ms_accumulator.can_remove_all(&cloned_removals);
+
+        // Apply all removal records in one batch. The batch application
+        // produces the same accumulator, removal records and authenticated
+        // items as applying the records one at a time: the Bloom filter
+        // insertions commute.
+        RemovalRecord::batch_update_from_removals(removal_records, &cloned_removals);
+        let mut preserved_membership_proofs = authenticated_items
+            .iter_mut()
+            .map(|authenticated_item| &mut authenticated_item.ms_membership_proof)
+            .collect::<Vec<_>>();
+        ms_accumulator.batch_remove(cloned_removals, &mut preserved_membership_proofs);
 
         removal_records_are_valid
     }
@@ -284,6 +276,309 @@ mod tests {
         msa_and_records: MsaAndRecords,
     ) {
         prop_assert!(prop(msa_and_records).is_ok())
+    }
+
+    mod batch_apply {
+        use itertools::Itertools;
+        use crate::util_types::mutator_set::authenticated_item::AuthenticatedItem;
+        use crate::util_types::mutator_set::commit;
+        use crate::util_types::mutator_set::msa_and_records::MsaAndRecords;
+        use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
+        use crate::util_types::mutator_set::removal_record::absolute_index_set::AbsoluteIndexSet;
+        use crate::util_types::mutator_set::removal_record::chunk_dictionary::ChunkDictionary;
+        use crate::util_types::mutator_set::removal_record::RemovalRecord;
+        use crate::util_types::mutator_set::shared::NUM_TRIALS;
+        use proptest::collection::vec;
+        use proptest::prelude::TestCaseError;
+        use proptest::prop_assert;
+        use proptest::prop_assert_eq;
+        use proptest_arbitrary_interop::arb;
+        use tasm_lib::prelude::Digest;
+        use test_strategy::proptest;
+
+        use super::MutatorSetUpdate;
+
+        /// The sequential implementation that
+        /// `apply_to_accumulator_and_records_inner` used before batch
+        /// application, kept as a reference for differential testing.
+        ///
+        /// Practially like the production code but without using the fastest
+        /// possible batch method for removal record maintanence. Weaker than
+        /// the production code since the `can_remove` check is applied in-order
+        /// here, and in an order-independent way in the production code. This
+        /// weakness can, in the consensus path, only be hit with negligible
+        /// (read: ~2^(-160)) probability. So switching to the batching-version
+        /// in the production code is technically a softfork, just one that can
+        /// only be hit with negligible probability.
+        fn sequential_apply_reference(
+            update: &MutatorSetUpdate,
+            ms_accumulator: &mut MutatorSetAccumulator,
+            removal_records: &mut [&mut RemovalRecord],
+            authenticated_items: &mut [&mut AuthenticatedItem],
+        ) -> bool {
+            let mut cloned_removals = update.removals.clone();
+            let mut remaining_removal_records =
+                cloned_removals.iter_mut().rev().collect::<Vec<_>>();
+            for addition_record in &update.additions {
+                RemovalRecord::batch_update_from_addition(
+                    &mut remaining_removal_records,
+                    ms_accumulator,
+                );
+                RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
+                AuthenticatedItem::batch_update_from_addition(
+                    authenticated_items,
+                    ms_accumulator,
+                    *addition_record,
+                );
+                ms_accumulator.add(addition_record);
+            }
+
+            let mut removal_records_are_valid = true;
+            while let Some(applied_removal_record) = remaining_removal_records.pop() {
+                RemovalRecord::batch_update_from_remove(
+                    &mut remaining_removal_records,
+                    applied_removal_record,
+                );
+                RemovalRecord::batch_update_from_remove(removal_records, applied_removal_record);
+                AuthenticatedItem::batch_update_from_remove(
+                    authenticated_items,
+                    applied_removal_record,
+                );
+                if !ms_accumulator.can_remove(applied_removal_record) {
+                    removal_records_are_valid = false;
+                }
+                ms_accumulator.remove(applied_removal_record);
+            }
+
+            removal_records_are_valid
+        }
+
+        fn batch_and_sequential_apply_agree(
+            msa_and_records: MsaAndRecords,
+            removables: Vec<(Digest, Digest, Digest)>,
+            num_removals: usize,
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) -> std::result::Result<(), TestCaseError> {
+            let all_records = msa_and_records.unpacked_removal_records();
+            let all_mps = &msa_and_records.membership_proofs;
+            let msa = &msa_and_records.mutator_set_accumulator;
+
+            let additions = addition_preimages
+                .iter()
+                .map(|(item, sender_randomness, receiver_preimage)| {
+                    commit(*item, *sender_randomness, receiver_preimage.hash())
+                })
+                .collect_vec();
+            let update = MutatorSetUpdate::new(all_records[..num_removals].to_vec(), additions);
+
+            // The records and authenticated items to be maintained through
+            // the application.
+            let preserved_records = all_records[num_removals..].to_vec();
+            let preserved_items = removables[num_removals..]
+                .iter()
+                .zip(&all_mps[num_removals..])
+                .map(|((item, _, _), ms_membership_proof)| AuthenticatedItem {
+                    item: *item,
+                    ms_membership_proof: ms_membership_proof.clone(),
+                })
+                .collect_vec();
+
+            let mut msa_batch = msa.clone();
+            let mut records_batch = preserved_records.clone();
+            let mut items_batch = preserved_items.clone();
+            let batch_result = update.apply_to_accumulator_and_records(
+                &mut msa_batch,
+                &mut records_batch.iter_mut().collect_vec(),
+                &mut items_batch.iter_mut().collect_vec(),
+            );
+
+            let mut msa_sequential = msa.clone();
+            let mut records_sequential = preserved_records.clone();
+            let mut items_sequential = preserved_items.clone();
+            let sequential_is_valid = sequential_apply_reference(
+                &update,
+                &mut msa_sequential,
+                &mut records_sequential.iter_mut().collect_vec(),
+                &mut items_sequential.iter_mut().collect_vec(),
+            );
+
+            prop_assert!(batch_result.is_ok());
+            prop_assert!(sequential_is_valid);
+            prop_assert_eq!(msa_sequential, msa_batch);
+            prop_assert_eq!(records_sequential, records_batch);
+            for (sequential, batch) in items_sequential.iter().zip(&items_batch) {
+                prop_assert_eq!(sequential.item, batch.item);
+                prop_assert_eq!(&sequential.ms_membership_proof, &batch.ms_membership_proof);
+            }
+
+            Ok(())
+        }
+
+        #[proptest(cases = 12)]
+        fn batch_apply_agrees_with_sequential_apply_u8(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::from(u8::MAX)))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 6)]
+        fn batch_apply_agrees_with_sequential_apply_u16(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::from(u16::MAX)))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 3)]
+        fn batch_apply_agrees_with_sequential_apply_u32(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::from(u32::MAX)))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 3)]
+        fn batch_apply_agrees_with_sequential_apply_u63(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::MAX / 2))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 10)]
+        fn duplicated_removal_record_invalidates_update(
+            #[strategy(1u64..=(u64::from(u8::MAX)))] _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 1))]
+            _removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#_removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+        ) {
+            let removal_record = msa_and_records.unpacked_removal_records()[0].clone();
+            let update =
+                MutatorSetUpdate::new(vec![removal_record.clone(), removal_record], vec![]);
+
+            let mut msa_batch = msa_and_records.mutator_set_accumulator.clone();
+            prop_assert!(update.apply_to_accumulator(&mut msa_batch).is_err());
+
+            let mut msa_sequential = msa_and_records.mutator_set_accumulator.clone();
+            let sequential_is_valid =
+                sequential_apply_reference(&update, &mut msa_sequential, &mut [], &mut []);
+            prop_assert!(!sequential_is_valid);
+
+            prop_assert_eq!(msa_sequential, msa_batch);
+        }
+
+        /// The batch check is stricter than sequential application in one
+        /// corner: a removal record whose indices are covered by the Bloom
+        /// filter and the *other* records of the update combined, without
+        /// being covered by the Bloom filter and earlier records alone.
+        /// passes sequentially but fails the batch check. For honestly
+        /// generated removal records this corner has negligible probability.
+        #[test]
+        fn batch_check_rejects_fully_covered_record_where_sequential_accepts() {
+            // All indices lie in the initial active window, so removal
+            // records with empty chunk dictionaries are valid.
+            fn removal_record(indices: [u128; NUM_TRIALS as usize]) -> RemovalRecord {
+                RemovalRecord {
+                    absolute_indices: AbsoluteIndexSet::new(indices),
+                    target_chunks: ChunkDictionary::default(),
+                }
+            }
+
+            // The pre-state has indices 0..45 set.
+            let pre_set = core::array::from_fn(|i| i as u128);
+            let mut msa = MutatorSetAccumulator::default();
+            MutatorSetUpdate::new(vec![removal_record(pre_set)], vec![])
+                .apply_to_accumulator(&mut msa)
+                .unwrap();
+
+            // The first record's indices are covered by the pre-state
+            // (0..20) and the second record (100..125) combined; the second
+            // record has twenty uncovered indices (200..220).
+            let first = core::array::from_fn(|i| {
+                if i < 20 {
+                    i as u128
+                } else {
+                    100 + (i as u128 - 20)
+                }
+            });
+            let second = core::array::from_fn(|i| {
+                if i < 25 {
+                    100 + i as u128
+                } else {
+                    200 + (i as u128 - 25)
+                }
+            });
+            let update =
+                MutatorSetUpdate::new(vec![removal_record(first), removal_record(second)], vec![]);
+
+            let mut msa_sequential = msa.clone();
+            let sequential_is_valid =
+                sequential_apply_reference(&update, &mut msa_sequential, &mut [], &mut []);
+            assert!(sequential_is_valid);
+
+            let mut msa_batch = msa.clone();
+            assert!(update.apply_to_accumulator(&mut msa_batch).is_err());
+
+            assert_eq!(msa_sequential, msa_batch);
+        }
     }
 
     mod compose {

--- a/xnt-core/src/protocol/consensus/block/mutator_set_update.rs
+++ b/xnt-core/src/protocol/consensus/block/mutator_set_update.rs
@@ -152,3 +152,61 @@ impl MutatorSetUpdate {
         removal_records_are_valid
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use proptest::collection::vec;
+    use proptest::prelude::TestCaseError;
+    use proptest::prop_assert;
+    use proptest_arbitrary_interop::arb;
+    use tasm_lib::prelude::Digest;
+    use test_strategy::proptest;
+
+    use super::MutatorSetUpdate;
+    use crate::util_types::mutator_set::msa_and_records::MsaAndRecords;
+
+    fn prop(msa_and_records: MsaAndRecords) -> std::result::Result<(), TestCaseError> {
+        let removal_records = msa_and_records.unpacked_removal_records();
+        for rr in &removal_records {
+            prop_assert!(msa_and_records.mutator_set_accumulator.can_remove(rr));
+        }
+
+        let original_msa = msa_and_records.mutator_set_accumulator;
+        for rr in removal_records {
+            let mut mutated_msa = original_msa.clone();
+            let as_msu = MutatorSetUpdate::new(vec![rr.clone()], vec![]);
+            prop_assert!(as_msu.apply_to_accumulator(&mut mutated_msa).is_ok());
+            prop_assert!(
+                !mutated_msa.can_remove(&rr),
+                "Can remove must return false after RR has been applied"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[proptest]
+    fn can_remove_agrees_with_update_result_u8(
+        #[strategy(0usize..40)] _num_removals: usize,
+        #[strategy((#_num_removals as u64)..=(u64::from(u8::MAX)))] _num_leafs_aocl: u64,
+        #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #_num_removals))]
+        _removables: Vec<(Digest, Digest, Digest)>,
+        #[strategy(MsaAndRecords::arbitrary_with((#_removables, #_num_leafs_aocl)))]
+        msa_and_records: MsaAndRecords,
+    ) {
+        prop_assert!(prop(msa_and_records).is_ok())
+    }
+
+    #[proptest(cases = 10)]
+    fn can_remove_agrees_with_update_result_u16(
+        #[strategy(0usize..40)] _num_removals: usize,
+        #[strategy((#_num_removals as u64)..=(u64::from(u16::MAX)))] _num_leafs_aocl: u64,
+        #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #_num_removals))]
+        _removables: Vec<(Digest, Digest, Digest)>,
+        #[strategy(MsaAndRecords::arbitrary_with((#_removables, #_num_leafs_aocl)))]
+        msa_and_records: MsaAndRecords,
+    ) {
+        prop_assert!(prop(msa_and_records).is_ok())
+    }
+}

--- a/xnt-core/src/protocol/consensus/block/mutator_set_update.rs
+++ b/xnt-core/src/protocol/consensus/block/mutator_set_update.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
+use tasm_lib::twenty_first::util_types::mmr::mmr_trait::Mmr;
 
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
 use crate::util_types::mutator_set::authenticated_item::AuthenticatedItem;
@@ -32,6 +33,81 @@ impl MutatorSetUpdate {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.removals.is_empty() && self.additions.is_empty()
+    }
+
+    /// Compose a chain of mutator-set updates into a single update.
+    ///
+    /// Mutator-set updates compose like arrows between mutator-set states:
+    /// given `A -> B` and `B -> C`, this returns `A -> C`. Concatenating the
+    /// addition and removal records is only a part of that. Each removal
+    /// record carries MMR-authentication paths and chunks derived against the
+    /// state it was made for, and an arrow out of `A` is only well-formed once
+    /// those are re-derived against `A`. To that end, the removal records
+    /// collected from later updates are reverted over each earlier update, one
+    /// update at a time, until they reach `A`.
+    ///
+    /// `chain` is ordered from the most recent update going backwards, e.g.
+    /// from a chain tip towards older blocks. Each element holds the mutator
+    /// set accumulator that an update applies to, along with the update
+    /// itself. The records in the returned update are ordered forwards, ready
+    /// for sequential application to `A`.
+    pub fn compose(chain: &[(MutatorSetAccumulator, MutatorSetUpdate)]) -> MutatorSetUpdate {
+        // All removal records collected so far, valid at the state that the
+        // most recently processed update applies to, in forward application
+        // order.
+        let mut composed_removals: Vec<RemovalRecord> = vec![];
+        let mut addition_batches_reversed: Vec<&Vec<AdditionRecord>> = vec![];
+
+        for (predecessor_msa, update) in chain {
+            if !composed_removals.is_empty() {
+                // Reverting the collected records over this update requires
+                // the update's own removal records synced to the update's
+                // resulting state, as sources of authentication data. Replay
+                // the additions on the predecessor accumulator, then bring
+                // the records through the application of all the update's
+                // removals — including themselves — in one combined pass.
+                let mut replay_msa = predecessor_msa.clone();
+                let mut applied_removals = update.removals.clone();
+                for addition_record in &update.additions {
+                    RemovalRecord::batch_update_from_addition(
+                        &mut applied_removals.iter_mut().collect::<Vec<_>>(),
+                        &replay_msa,
+                    );
+                    replay_msa.add(addition_record);
+                }
+                let pre_removal_forms = applied_removals.clone();
+                RemovalRecord::batch_update_from_removals(
+                    &mut applied_removals.iter_mut().collect::<Vec<_>>(),
+                    &pre_removal_forms,
+                );
+
+                // Walk the collected records back to the state that this
+                // update applies to: undo all the removals in one pass, then
+                // the additions.
+                RemovalRecord::batch_revert_update_from_removals(
+                    &mut composed_removals.iter_mut().collect::<Vec<_>>(),
+                    &applied_removals,
+                );
+                RemovalRecord::batch_revert_update_from_addition(
+                    &mut composed_removals.iter_mut().collect::<Vec<_>>(),
+                    predecessor_msa.swbf_inactive.num_leafs(),
+                );
+            }
+
+            // This update's own removal records, as stored, are already valid
+            // at the state that the update applies to. They apply before
+            // everything collected so far.
+            composed_removals.splice(0..0, update.removals.iter().cloned());
+            addition_batches_reversed.push(&update.additions);
+        }
+
+        let composed_additions = addition_batches_reversed
+            .into_iter()
+            .rev()
+            .flatten()
+            .copied()
+            .collect();
+        MutatorSetUpdate::new(composed_removals, composed_additions)
     }
 
     /// Like `apply_to_accumulator` but does not verify that the removal records
@@ -208,5 +284,215 @@ mod tests {
         msa_and_records: MsaAndRecords,
     ) {
         prop_assert!(prop(msa_and_records).is_ok())
+    }
+
+    mod compose {
+        use itertools::Itertools;
+        use crate::util_types::mutator_set::addition_record::AdditionRecord;
+        use crate::util_types::mutator_set::authenticated_item::AuthenticatedItem;
+        use crate::util_types::mutator_set::commit;
+        use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
+        use crate::util_types::mutator_set::removal_record::RemovalRecord;
+        use crate::util_types::mutator_set::shared::BATCH_SIZE;
+        use crate::util_types::test_shared::mutator_set::mock_item_and_randomnesses;
+        use rand::Rng;
+
+        use super::MutatorSetUpdate;
+
+        #[test]
+        fn compose_three_updates_into_one() {
+            // Construct three valid updates, and compose them into one. Verify the
+            // correctness of the composed update.
+            let mut accumulator = MutatorSetAccumulator::default();
+
+            let (initial_ars, (items, (srs, rps))): (Vec<_>, (Vec<_>, (Vec<_>, Vec<_>))) = (0..100)
+                .map(|_| {
+                    let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                    (
+                        commit(item, sender_randomness, receiver_preimage.hash()),
+                        (item, (sender_randomness, receiver_preimage)),
+                    )
+                })
+                .collect_vec()
+                .into_iter()
+                .unzip();
+
+            // List of consistent pairs of (mutator set acc, update) where the
+            // update's removal records are valid under the mutator set acc.
+            let mut states = vec![(
+                accumulator.clone(),
+                MutatorSetUpdate::new(vec![], initial_ars.clone()),
+            )];
+
+            let mut auth_items = vec![];
+            for j in 0..100 {
+                AuthenticatedItem::batch_update_from_addition(
+                    &mut auth_items.iter_mut().collect_vec(),
+                    &accumulator,
+                    initial_ars[j],
+                );
+                auth_items.push(AuthenticatedItem {
+                    item: items[j],
+                    ms_membership_proof: accumulator.prove(items[j], srs[j], rps[j]),
+                });
+                accumulator.add(&initial_ars[j]);
+            }
+
+            // Construct and apply the next two consistent updates
+            for j in 0..=1 {
+                // Construct all addition records/removal records before applying
+                // anything, as all cryptographic data must only be valid against
+                // the snapshotted accumulator.
+                let mut addition_records = vec![];
+                for _ in 0..100 {
+                    let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                    let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+                    addition_records.push(addition_record);
+                }
+
+                let rrs = auth_items
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| i % 3 == j)
+                    .map(|(_, auth_item)| {
+                        accumulator.drop(auth_item.item, &auth_item.ms_membership_proof)
+                    })
+                    .collect_vec();
+
+                let update = MutatorSetUpdate::new(rrs, addition_records);
+                states.push((accumulator.clone(), update.clone()));
+
+                update
+                    .apply_to_accumulator_and_records(
+                        &mut accumulator,
+                        &mut [],
+                        &mut auth_items.iter_mut().collect_vec(),
+                    )
+                    .unwrap();
+            }
+
+            states.reverse();
+
+            let composed = MutatorSetUpdate::compose(&states);
+
+            let mut rebuilt_from_composition = MutatorSetAccumulator::default();
+            composed
+                .apply_to_accumulator(&mut rebuilt_from_composition)
+                .unwrap();
+
+            assert_eq!(accumulator, rebuilt_from_composition)
+        }
+
+        #[test]
+        fn compose_block_mutations_equals_sequential_application() {
+            let mut rng = rand::rng();
+            let mut accumulator = MutatorSetAccumulator::default();
+
+            // A pool of live removal records, kept synced to the accumulator, for
+            // the updates to draw their removals from. `pool_tags` records, per
+            // pool entry, whether the removed item predates the chain of updates.
+            let mut pool: Vec<RemovalRecord> = vec![];
+            let mut pool_tags: Vec<bool> = vec![];
+            let add_item = |accumulator: &mut MutatorSetAccumulator,
+                            pool: &mut Vec<RemovalRecord>|
+             -> AdditionRecord {
+                let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+                let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+                RemovalRecord::batch_update_from_addition(
+                    &mut pool.iter_mut().collect::<Vec<_>>(),
+                    accumulator,
+                );
+                accumulator.add(&addition_record);
+                pool.push(accumulator.drop(item, &mp));
+                addition_record
+            };
+
+            // Seed the accumulator so the first update has something to remove.
+            for _ in 0..(2 * BATCH_SIZE) {
+                add_item(&mut accumulator, &mut pool);
+            }
+            pool_tags.extend(std::iter::repeat_n(true, pool.len()));
+
+            // Build a chain of updates, each with additions and removals, applied
+            // to the accumulator as it goes.
+            let old_msa = accumulator.clone();
+            let num_updates = 6;
+            let mut chain = vec![];
+            let mut chain_tags = vec![];
+            for _ in 0..num_updates {
+                let predecessor_msa = accumulator.clone();
+
+                // Draw this update's removals from the pool. Their pre-update
+                // form goes into the chain; the working copies follow the
+                // update's application.
+                let mut working_removals = vec![];
+                let mut update_tags = vec![];
+                for _ in 0..2 {
+                    let draw = rng.random_range(0..pool.len());
+                    working_removals.push(pool.remove(draw));
+                    update_tags.push(pool_tags.remove(draw));
+                }
+                let stored_removals = working_removals.clone();
+
+                // Create and apply the additions one at a time, keeping the pool
+                // and the pending removals in sync.
+                let mut additions = vec![];
+                for _ in 0..4 {
+                    let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                    let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+                    let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+                    RemovalRecord::batch_update_from_addition(
+                        &mut pool
+                            .iter_mut()
+                            .chain(working_removals.iter_mut())
+                            .collect::<Vec<_>>(),
+                        &accumulator,
+                    );
+                    accumulator.add(&addition_record);
+                    pool.push(accumulator.drop(item, &mp));
+                    pool_tags.push(false);
+                    additions.push(addition_record);
+                }
+
+                // Apply the removals, keeping the pool in sync.
+                MutatorSetUpdate::new(working_removals, vec![])
+                    .apply_to_accumulator_and_records(
+                        &mut accumulator,
+                        &mut pool.iter_mut().collect::<Vec<_>>(),
+                        &mut [],
+                    )
+                    .unwrap();
+
+                chain.push((
+                    predecessor_msa,
+                    MutatorSetUpdate::new(stored_removals, additions),
+                ));
+                chain_tags.push(update_tags);
+            }
+            let tip_hash = accumulator.hash();
+
+            // Compose the chain, most recent update first.
+            chain.reverse();
+            chain_tags.reverse();
+            let composed = MutatorSetUpdate::compose(&chain);
+
+            // Composed removal records for items that predate the chain must be
+            // valid at the old state. Records for items added within the chain
+            // itself cannot be: those become valid only as the replay of the
+            // additions progresses, which the application below checks.
+            let composed_tags = chain_tags.iter().rev().flatten().collect::<Vec<_>>();
+            assert_eq!(composed_tags.len(), composed.removals.len());
+            for (born_before_chain, removal_record) in composed_tags.iter().zip(&composed.removals)
+            {
+                if **born_before_chain {
+                    assert!(removal_record.validate(&old_msa));
+                    assert!(old_msa.can_remove(removal_record));
+                }
+            }
+            let mut replay_msa = old_msa;
+            composed.apply_to_accumulator(&mut replay_msa).unwrap();
+            assert_eq!(tip_hash, replay_msa.hash());
+        }
     }
 }

--- a/xnt-core/src/protocol/consensus/consensus_rule_set.rs
+++ b/xnt-core/src/protocol/consensus/consensus_rule_set.rs
@@ -297,6 +297,73 @@ impl ConsensusRuleSet {
             | ConsensusRuleSet::UpgradeVMv7 => MAX_NUM_INPUTS_OUTPUTS_ANNOUNCEMENTS,
         }
     }
+
+    /// How many inputs, outputs, and announcements a block reserves for the
+    /// transactions that a mempool transaction is merged with before it can be
+    /// mined: the composer's coinbase transaction, which typically has two
+    /// outputs, and possibly a negative-fee transaction whose author claims
+    /// part of the fee.
+    const MERGE_HEADROOM: usize = 5;
+
+    /// The largest number of inputs a transaction may have and still be worth
+    /// admitting to the mempool.
+    ///
+    /// A transaction above this limit can never be mined, because the merged
+    /// block transaction would exceed [`max_num_inputs`](Self::max_num_inputs).
+    /// Relaying or storing it only spends bandwidth and memory.
+    pub(crate) fn max_num_inputs_in_mempool(&self) -> usize {
+        self.max_num_inputs().saturating_sub(Self::MERGE_HEADROOM)
+    }
+
+    /// Mempool counterpart of [`max_num_outputs`](Self::max_num_outputs); see
+    /// [`max_num_inputs_in_mempool`](Self::max_num_inputs_in_mempool).
+    pub(crate) fn max_num_outputs_in_mempool(&self) -> usize {
+        self.max_num_outputs().saturating_sub(Self::MERGE_HEADROOM)
+    }
+
+    /// Mempool counterpart of
+    /// [`max_num_announcements`](Self::max_num_announcements); see
+    /// [`max_num_inputs_in_mempool`](Self::max_num_inputs_in_mempool).
+    pub(crate) fn max_num_announcements_in_mempool(&self) -> usize {
+        self.max_num_announcements()
+            .saturating_sub(Self::MERGE_HEADROOM)
+    }
+
+    /// Whether a transaction is small enough to be admitted to the mempool.
+    ///
+    /// Returns the offending item kind if any count is above its mempool limit.
+    pub(crate) fn mempool_size_check(
+        &self,
+        num_inputs: usize,
+        num_outputs: usize,
+        num_announcements: usize,
+    ) -> Result<(), TransactionTooBig> {
+        if num_inputs > self.max_num_inputs_in_mempool() {
+            return Err(TransactionTooBig::TooManyInputs);
+        }
+        if num_outputs > self.max_num_outputs_in_mempool() {
+            return Err(TransactionTooBig::TooManyOutputs);
+        }
+        if num_announcements > self.max_num_announcements_in_mempool() {
+            return Err(TransactionTooBig::TooManyAnnouncements);
+        }
+
+        Ok(())
+    }
+}
+
+/// Why a transaction is too big to be admitted to the mempool. See
+/// [`ConsensusRuleSet::mempool_size_check`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TransactionTooBig {
+    #[error("transaction has more inputs than can be mined")]
+    TooManyInputs,
+
+    #[error("transaction has more outputs than can be mined")]
+    TooManyOutputs,
+
+    #[error("transaction has more announcements than can be mined")]
+    TooManyAnnouncements,
 }
 
 #[cfg(test)]
@@ -309,6 +376,7 @@ pub(crate) mod tests {
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
+    use strum::IntoEnumIterator;
     use tracing_test::traced_test;
 
     use super::*;
@@ -346,6 +414,48 @@ pub(crate) mod tests {
     use crate::tests::shared::blocks::next_block;
     use crate::tests::shared::globalstate::mock_genesis_global_state_with_block;
     use crate::tests::tokio_runtime;
+
+    /// A transaction is admissible right up to the mempool limit, and rejected
+    /// one item beyond it, for each of the three item kinds.
+    ///
+    /// The mempool limit sits [`ConsensusRuleSet::MERGE_HEADROOM`] below the
+    /// block limit, so that a transaction admitted here still fits in a block
+    /// after being merged with the composer's coinbase transaction.
+    #[test]
+    fn mempool_size_check_is_exact_at_the_limit() {
+        for rule_set in ConsensusRuleSet::iter() {
+            let max_inputs = rule_set.max_num_inputs_in_mempool();
+            let max_outputs = rule_set.max_num_outputs_in_mempool();
+            let max_announcements = rule_set.max_num_announcements_in_mempool();
+
+            assert!(
+                max_inputs < rule_set.max_num_inputs(),
+                "{rule_set}: mempool limit must leave headroom below the block limit"
+            );
+
+            assert_eq!(
+                Ok(()),
+                rule_set.mempool_size_check(max_inputs, max_outputs, max_announcements),
+                "{rule_set}: a transaction exactly at the limit must be admissible"
+            );
+
+            assert_eq!(
+                Err(TransactionTooBig::TooManyInputs),
+                rule_set.mempool_size_check(max_inputs + 1, 0, 0),
+                "{rule_set}: one input too many must be rejected"
+            );
+            assert_eq!(
+                Err(TransactionTooBig::TooManyOutputs),
+                rule_set.mempool_size_check(0, max_outputs + 1, 0),
+                "{rule_set}: one output too many must be rejected"
+            );
+            assert_eq!(
+                Err(TransactionTooBig::TooManyAnnouncements),
+                rule_set.mempool_size_check(0, 0, max_announcements + 1),
+                "{rule_set}: one announcement too many must be rejected"
+            );
+        }
+    }
 
     async fn tx_with_n_outputs(
         mut state: GlobalStateLock,

--- a/xnt-core/src/protocol/consensus/transaction/transaction_kernel.rs
+++ b/xnt-core/src/protocol/consensus/transaction/transaction_kernel.rs
@@ -121,7 +121,6 @@ impl TransactionKernel {
         // check validity of removal records
         //       ^^^^^^^^
 
-        // meaning: a) all required membership proofs exist; and b) are valid.
         let inputs = &self.inputs;
         let maybe_invalid_removal_record = inputs
             .iter()

--- a/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -423,6 +423,21 @@ impl ProofCollection {
         }
     }
 
+    /// Whether there is exactly one halting proof per collected script hash.
+    ///
+    /// The verification loops in [`verify`](Self::verify) and
+    /// [`verify_v2`](Self::verify_v2) pair claims with proofs using `zip`, which
+    /// silently truncates to the shorter operand; without this guard a prover
+    /// could submit fewer (e.g. zero) `*_scripts_halt` proofs than
+    /// `*_script_hashes` and have the surplus lock-/type-script checks skipped
+    /// while verification still returns `true`. Reject the
+    /// (attacker-controlled) length mismatch as invalid here rather than via
+    /// `zip_eq`, which would panic on untrusted input.
+    fn halt_proof_counts_match(&self) -> bool {
+        self.lock_scripts_halt.len() == self.lock_script_hashes.len()
+            && self.type_scripts_halt.len() == self.type_script_hashes.len()
+    }
+
     pub(crate) async fn verify(&self, txk_mast_hash: Digest, network: Network) -> bool {
         debug!("verifying, txk hash: {}", txk_mast_hash);
         debug!("verifying, salted inputs hash: {}", self.salted_inputs_hash);
@@ -435,16 +450,7 @@ impl ProofCollection {
             return false;
         }
 
-        // There must be exactly one halting proof per collected script hash.
-        // The verification loops below use `zip`, which silently truncates to the
-        // shorter operand; without this guard a prover could submit fewer (e.g.
-        // zero) `*_scripts_halt` proofs than `*_script_hashes` and have the
-        // surplus lock-/type-script checks skipped while `verify` still returns
-        // `true`. Reject the (attacker-controlled) length mismatch as invalid
-        // here rather than via `zip_eq`, which would panic on untrusted input.
-        if self.lock_scripts_halt.len() != self.lock_script_hashes.len()
-            || self.type_scripts_halt.len() != self.type_script_hashes.len()
-        {
+        if !self.halt_proof_counts_match() {
             return false;
         }
 
@@ -562,6 +568,10 @@ impl ProofCollection {
         use crate::protocol::consensus::transaction::validity::collect_type_scripts_v2::CollectTypeScriptsV2;
         debug!("verifying (V2), txk hash: {}", txk_mast_hash);
         if self.kernel_mast_hash != txk_mast_hash {
+            return false;
+        }
+
+        if !self.halt_proof_counts_match() {
             return false;
         }
 
@@ -841,6 +851,54 @@ pub mod tests {
             !missing_type_proofs.verify(txk, network).await,
             "non-empty type_script_hashes with no type_scripts_halt must be rejected"
         );
+    }
+
+    /// The V2 verification path must reject the same mismatches as `verify`.
+    ///
+    /// `verify_v2` has no upstream counterpart — it is this chain's post-fork
+    /// validation path — so the guard has to be asserted separately here. Were
+    /// it applied only to `verify`, every transaction validated after the V2
+    /// fork would still skip its lock- and type-script checks.
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn verify_v2_rejects_halt_proof_count_mismatch() {
+        let mut test_runner = TestRunner::deterministic();
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 1)
+            .new_tree(&mut test_runner)
+            .unwrap()
+            .current();
+        let txk = primitive_witness.kernel.mast_hash();
+
+        let network = Network::RegTest;
+        let valid = ProofCollection::produce_mock(&primitive_witness, true);
+        assert!(!valid.lock_script_hashes.is_empty());
+        assert!(!valid.type_script_hashes.is_empty());
+        assert!(
+            valid.verify_v2(txk, network).await,
+            "sanity: a well-formed valid-mock collection must verify under V2"
+        );
+
+        let mutations: [(&str, fn(ProofCollection) -> ProofCollection); 3] = [
+            ("no lock-script proofs", |mut pc| {
+                pc.lock_scripts_halt.clear();
+                pc
+            }),
+            ("no type-script proofs", |mut pc| {
+                pc.type_scripts_halt.clear();
+                pc
+            }),
+            ("one lock-script proof too few", |mut pc| {
+                pc.lock_scripts_halt.pop();
+                pc
+            }),
+        ];
+
+        for (description, mutate) in mutations {
+            assert!(
+                !mutate(valid.clone()).verify_v2(txk, network).await,
+                "verify_v2 must reject a collection with {description}"
+            );
+        }
     }
 
     #[proptest(cases = 5)]

--- a/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -435,6 +435,19 @@ impl ProofCollection {
             return false;
         }
 
+        // There must be exactly one halting proof per collected script hash.
+        // The verification loops below use `zip`, which silently truncates to the
+        // shorter operand; without this guard a prover could submit fewer (e.g.
+        // zero) `*_scripts_halt` proofs than `*_script_hashes` and have the
+        // surplus lock-/type-script checks skipped while `verify` still returns
+        // `true`. Reject the (attacker-controlled) length mismatch as invalid
+        // here rather than via `zip_eq`, which would panic on untrusted input.
+        if self.lock_scripts_halt.len() != self.lock_script_hashes.len()
+            || self.type_scripts_halt.len() != self.type_script_hashes.len()
+        {
+            return false;
+        }
+
         // compile claims
         let removal_records_integrity_claim =
             Claim::about_program(&RemovalRecordsIntegrity.program())
@@ -783,6 +796,51 @@ pub mod tests {
                 }
             }
         }
+    }
+
+    /// Regression test for the `.zip()` truncation bug (opus48_neptune_cash7.md):
+    /// `verify` must reject a collection whose `*_scripts_halt` proof count
+    /// differs from its `*_script_hashes` count. Before the length guard, `zip`
+    /// silently truncated to the shorter side, so a collection with zero halting
+    /// proofs but non-empty hashes was accepted — skipping every lock-script
+    /// (spend authorization) and type-script (value conservation) check.
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn verify_rejects_halt_proof_count_mismatch() {
+        let mut test_runner = TestRunner::deterministic();
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 1)
+            .new_tree(&mut test_runner)
+            .unwrap()
+            .current();
+        let txk = primitive_witness.kernel.mast_hash();
+
+        // RegTest accepts valid mock proofs, so a well-formed mock collection
+        // verifies. This isolates the length guard as the sole reason a mutated
+        // collection is rejected.
+        let network = Network::RegTest;
+        let valid = ProofCollection::produce_mock(&primitive_witness, true);
+        assert!(!valid.lock_script_hashes.is_empty());
+        assert!(!valid.type_script_hashes.is_empty());
+        assert!(
+            valid.verify(txk, network).await,
+            "sanity: a well-formed valid-mock collection must verify"
+        );
+
+        // Drop the lock-script halting proofs (the part needing the spender's key).
+        let mut missing_lock_proofs = valid.clone();
+        missing_lock_proofs.lock_scripts_halt.clear();
+        assert!(
+            !missing_lock_proofs.verify(txk, network).await,
+            "non-empty lock_script_hashes with no lock_scripts_halt must be rejected"
+        );
+
+        // Drop the type-script halting proofs (value conservation).
+        let mut missing_type_proofs = valid.clone();
+        missing_type_proofs.type_scripts_halt.clear();
+        assert!(
+            !missing_type_proofs.verify(txk, network).await,
+            "non-empty type_script_hashes with no type_scripts_halt must be rejected"
+        );
     }
 
     #[proptest(cases = 5)]

--- a/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use tasm_lib::prelude::Digest;
 use tasm_lib::structure::tasm_object::TasmObject;
 use tasm_lib::triton_vm::prelude::*;
+use tasm_lib::twenty_first::prelude::MerkleTreeInclusionProof;
 use tracing::debug;
 use tracing::info;
 use tracing::trace;
@@ -18,6 +19,7 @@ use crate::api::tx_initiation::error::CreateProofError;
 use crate::application::config::network::Network;
 use crate::application::triton_vm_job_queue::TritonVmJobQueue;
 use crate::protocol::consensus::transaction::primitive_witness::PrimitiveWitness;
+use crate::protocol::consensus::transaction::transaction_kernel::TransactionKernel;
 use crate::protocol::consensus::transaction::transaction_kernel::TransactionKernelField;
 use crate::protocol::consensus::transaction::validity::collect_lock_scripts::CollectLockScripts;
 use crate::protocol::consensus::transaction::validity::collect_lock_scripts::CollectLockScriptsWitness;
@@ -26,6 +28,7 @@ use crate::protocol::consensus::transaction::validity::kernel_to_outputs::Kernel
 use crate::protocol::consensus::transaction::validity::neptune_proof::Proof;
 use crate::protocol::consensus::transaction::validity::removal_records_integrity::RemovalRecordsIntegrityWitness;
 use crate::protocol::consensus::transaction::BFieldCodec;
+use crate::protocol::proof_abstractions::mast_hash::HasDiscriminant;
 use crate::protocol::proof_abstractions::mast_hash::MastHash;
 use crate::protocol::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::protocol::proof_abstractions::tasm::program::TritonVmProofJobOptions;
@@ -438,6 +441,25 @@ impl ProofCollection {
             && self.type_scripts_halt.len() == self.type_script_hashes.len()
     }
 
+    /// Whether the collection proves that the kernel's merge bit is *unset*.
+    ///
+    /// A `ProofCollection` may only back an unmerged transaction: the merged
+    /// variant is proven by `SingleProof`. The collection carries a MAST
+    /// authentication path for the merge-bit field, and the leaf value checked
+    /// here is hardcoded to `false`, so a collection whose kernel has the merge
+    /// bit set cannot authenticate — regardless of the path it supplies.
+    fn proves_unset_merge_bit(&self, txk_mast_hash: Digest) -> bool {
+        MerkleTreeInclusionProof {
+            tree_height: TransactionKernel::MAST_HEIGHT.try_into().unwrap(),
+            indexed_leafs: vec![(
+                TransactionKernelField::MergeBit.discriminant(),
+                Tip5::hash(&false),
+            )],
+            authentication_structure: self.merge_bit_mast_path.clone(),
+        }
+        .verify(txk_mast_hash)
+    }
+
     pub(crate) async fn verify(&self, txk_mast_hash: Digest, network: Network) -> bool {
         debug!("verifying, txk hash: {}", txk_mast_hash);
         debug!("verifying, salted inputs hash: {}", self.salted_inputs_hash);
@@ -451,6 +473,10 @@ impl ProofCollection {
         }
 
         if !self.halt_proof_counts_match() {
+            return false;
+        }
+
+        if !self.proves_unset_merge_bit(txk_mast_hash) {
             return false;
         }
 
@@ -577,6 +603,10 @@ impl ProofCollection {
         }
 
         if !self.halt_proof_counts_match() {
+            return false;
+        }
+
+        if !self.proves_unset_merge_bit(txk_mast_hash) {
             return false;
         }
 
@@ -747,6 +777,7 @@ pub mod tests {
     use crate::api::export::NeptuneProof;
     use crate::application::triton_vm_job_queue::vm_job_queue;
     use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+    use crate::protocol::consensus::transaction::transaction_kernel::TransactionKernelModifier;
     use crate::tests::shared_tokio_runtime;
 
     impl ProofCollection {
@@ -855,6 +886,51 @@ pub mod tests {
         assert!(
             !missing_type_proofs.verify(txk, network).await,
             "non-empty type_script_hashes with no type_scripts_halt must be rejected"
+        );
+    }
+
+    /// Neither verification path may accept a collection whose kernel has the
+    /// merge bit set: a `ProofCollection` only ever backs an unmerged
+    /// transaction, the merged variant being proven by `SingleProof`.
+    ///
+    /// The collection below is *derived from the modified kernel*, so its
+    /// merge-bit MAST path correctly authenticates `true` under the new kernel
+    /// MAST hash. It must still be rejected, because the leaf value the guard
+    /// checks is hardcoded to `false`.
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn verify_rejects_a_set_merge_bit() {
+        let mut test_runner = TestRunner::deterministic();
+        let mut primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 1)
+            .new_tree(&mut test_runner)
+            .unwrap()
+            .current();
+
+        let network = Network::RegTest;
+        let merge_bit_false = ProofCollection::produce_mock(&primitive_witness, true);
+        let txk_unmerged = primitive_witness.kernel.mast_hash();
+        assert!(
+            merge_bit_false.verify(txk_unmerged, network).await,
+            "sanity: an unmerged collection must verify"
+        );
+        assert!(
+            merge_bit_false.verify_v2(txk_unmerged, network).await,
+            "sanity: an unmerged collection must verify under V2"
+        );
+
+        primitive_witness.kernel = TransactionKernelModifier::default()
+            .merge_bit(true)
+            .modify(primitive_witness.kernel.clone());
+        let merge_bit_true = ProofCollection::produce_mock(&primitive_witness, true);
+        let txk_merged = primitive_witness.kernel.mast_hash();
+
+        assert!(
+            !merge_bit_true.verify(txk_merged, network).await,
+            "a collection whose kernel has the merge bit set must be rejected"
+        );
+        assert!(
+            !merge_bit_true.verify_v2(txk_merged, network).await,
+            "a collection whose kernel has the merge bit set must be rejected under V2"
         );
     }
 

--- a/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/xnt-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -510,54 +510,59 @@ impl ProofCollection {
             })
             .collect_vec();
 
-        // verify
-        debug!("verifying removal records integrity ...");
-        let rri = verify_transaction_proof(
-            removal_records_integrity_claim.clone(),
-            self.removal_records_integrity.clone(),
-            network,
-        )
-        .await;
-        debug!("{rri}");
-        debug!("verifying kernel to outputs ...");
-        let k2o = verify_transaction_proof(
-            kernel_to_outputs_claim.clone(),
-            self.kernel_to_outputs.clone(),
-            network,
-        )
-        .await;
-        debug!("{k2o}");
-        debug!("verifying collect lock scripts ...");
-        let cls = verify_transaction_proof(
-            collect_lock_scripts_claim.clone(),
-            self.collect_lock_scripts.clone(),
-            network,
-        )
-        .await;
-        debug!("{cls}");
-        debug!("verifying collect type scripts ...");
-        let cts = verify_transaction_proof(
-            collect_type_scripts_claim.clone(),
-            self.collect_type_scripts.clone(),
-            network,
-        )
-        .await;
-        debug!("{cts}");
-        debug!("verifying that all lock scripts halt ...");
-        let mut lsh = true;
-        for (cl, pr) in lock_script_claims.iter().zip(self.lock_scripts_halt.iter()) {
-            lsh &= verify_transaction_proof(cl.clone(), pr.clone(), network).await;
+        // Verify, returning on the first proof that fails.
+        //
+        // The two `collect_*_scripts` claims commit to the script-hash lists,
+        // and those lists' lengths decide how many proofs the loop below
+        // verifies. All four claims here are checked before that loop is
+        // entered, which bounds the work an attacker can make the victim do
+        // without constructing a valid transaction.
+        for (name, claim, proof) in [
+            (
+                "removal records integrity",
+                removal_records_integrity_claim,
+                &self.removal_records_integrity,
+            ),
+            (
+                "kernel to outputs",
+                kernel_to_outputs_claim,
+                &self.kernel_to_outputs,
+            ),
+            (
+                "collect lock scripts",
+                collect_lock_scripts_claim,
+                &self.collect_lock_scripts,
+            ),
+            (
+                "collect type scripts",
+                collect_type_scripts_claim,
+                &self.collect_type_scripts,
+            ),
+        ] {
+            debug!("verifying {name} ...");
+            if !verify_transaction_proof(claim, proof.clone(), network).await {
+                debug!("{name} is invalid");
+                return false;
+            }
         }
-        debug!("{lsh}");
-        debug!("verifying that all type scripts halt ...");
-        let mut tsh = true;
-        for (cl, pr) in type_script_claims.iter().zip(self.type_scripts_halt.iter()) {
-            tsh &= verify_transaction_proof(cl.clone(), pr.clone(), network).await;
-        }
-        debug!("{tsh}");
 
-        // and all bits together and return
-        rri && k2o && cls && cts && lsh && tsh
+        debug!("verifying that all lock scripts halt ...");
+        for (claim, proof) in lock_script_claims.into_iter().zip(&self.lock_scripts_halt) {
+            if !verify_transaction_proof(claim, proof.clone(), network).await {
+                debug!("a lock script does not halt gracefully");
+                return false;
+            }
+        }
+
+        debug!("verifying that all type scripts halt ...");
+        for (claim, proof) in type_script_claims.into_iter().zip(&self.type_scripts_halt) {
+            if !verify_transaction_proof(claim, proof.clone(), network).await {
+                debug!("a type script does not halt gracefully");
+                return false;
+            }
+        }
+
+        true
     }
 
     /// V2 counterpart of [`verify`]. Identical except that the inline

--- a/xnt-core/src/protocol/peer.rs
+++ b/xnt-core/src/protocol/peer.rs
@@ -12,6 +12,7 @@ use std::time::SystemTime;
 use handshake_data::HandshakeData;
 use itertools::Itertools;
 use num_bigint::BigUint;
+use num_traits::CheckedSub;
 use num_traits::ToPrimitive;
 use num_traits::Zero;
 use peer_block_notifications::PeerBlockNotification;
@@ -892,8 +893,14 @@ impl SyncChallengeResponse {
 
         let first = self.blocks[0].0.header;
         let last = self.tip.header;
-        let total_pow_increase = BigUint::from(last.cumulative_proof_of_work)
-            - BigUint::from(first.cumulative_proof_of_work);
+
+        // Cum-pow values are the responder's to choose, so the difference is
+        // not known to be positive.
+        let Some(total_pow_increase) = BigUint::from(last.cumulative_proof_of_work)
+            .checked_sub(&BigUint::from(first.cumulative_proof_of_work))
+        else {
+            return false;
+        };
         let span = last.height - first.height;
         let average_difficulty = total_pow_increase.to_f64().unwrap() / (span as f64);
         debug_assert!(
@@ -1162,6 +1169,36 @@ mod tests {
                 &invalid_pow_chain
             ));
         }
+    }
+
+    #[test]
+    fn check_pow_rejects_first_block_with_more_work_than_last() {
+        use crate::protocol::consensus::block::block_header::HeaderToBlockHashWitness;
+        use crate::protocol::consensus::transaction::validity::neptune_proof::Proof;
+
+        let network = Network::Testnet(42);
+        let genesis = Block::genesis(network);
+        let block = TransferBlock {
+            header: *genesis.header(),
+            body: genesis.body().clone(),
+            appendix: genesis.appendix().clone(),
+            proof: Proof::invalid(),
+        };
+        let witness = BlockHeaderWithBlockHashWitness::new(
+            *genesis.header(),
+            HeaderToBlockHashWitness::from(&genesis),
+        );
+        let mut response = SyncChallengeResponse {
+            blocks: std::array::from_fn(|_| (block.clone(), block.clone())),
+            membership_proofs: std::array::from_fn(|_| MmrMembershipProof::new(vec![])),
+            tip_parent: block.clone(),
+            tip: block.clone(),
+            pow_witnesses: std::array::from_fn(|_| witness.clone()),
+        };
+        response.blocks[0].0.header.cumulative_proof_of_work =
+            block.header.cumulative_proof_of_work + [1u32];
+
+        assert!(!response.check_pow(network, 1u64.into()));
     }
 
     #[test]

--- a/xnt-core/src/state/archival_state.rs
+++ b/xnt-core/src/state/archival_state.rs
@@ -12,12 +12,12 @@ use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::SeekFrom;
 use tracing::debug;
+use tracing::info;
 use tracing::warn;
 
 pub(crate) mod import_blocks_from_files;
 
 use super::shared::new_block_file_is_needed;
-use super::StorageVecBase;
 use crate::api::export::Network;
 use crate::application::config::data_directory::DataDirectory;
 use crate::application::database::create_db_if_missing;
@@ -1123,7 +1123,7 @@ impl ArchivalState {
     /// max search depth, as it loads all the blocks in the search path into
     /// memory. A max search depth of 0 means that only the tip is checked.
     async fn mutator_set_to_tip_internal(
-        &mut self,
+        &self,
         old_ms_digest: Digest,
         old_aocl_num_leafs: Option<u64>,
         max_search_depth: usize,
@@ -1155,13 +1155,15 @@ impl ArchivalState {
                 return None;
             }
 
-            let MutatorSetUpdate {
-                removals,
-                additions,
-            } = haystack
+            let mutator_set_update = haystack
                 .mutator_set_update()
                 .expect("Block from state must have mutator set update");
-            block_mutations.push((additions, removals));
+            let predecessor_msa = parent
+                .as_ref()
+                .unwrap()
+                .mutator_set_accumulator_after()
+                .expect("Block from state must have mutator set after");
+            block_mutations.push((predecessor_msa, mutator_set_update));
 
             haystack = parent.unwrap();
             parent = self
@@ -1170,67 +1172,20 @@ impl ArchivalState {
                 .expect("Must succeed in reading block");
         };
 
-        // The removal records collected above were valid for each block but
-        // are in the general case not valid for the `mutator_set` which was
-        // given as input to this function. In order to find the right removal
-        // records, we, temporarily, roll back the state of the archival mutator
-        // set. This allows us to read out MMR-authentication paths from a
-        // previous state of the mutator set. It's crucial that these changes
-        // are not persisted, as that would leave the archival mutator set in a
-        // state incompatible with the tip.
-        self.archival_mutator_set.persist().await;
-        for (additions, removals) in &block_mutations {
-            for rr in removals.iter().rev() {
-                self.archival_mutator_set.ams_mut().revert_remove(rr).await;
-            }
-
-            for ar in additions.iter().rev() {
-                self.archival_mutator_set.ams_mut().revert_add(ar).await;
-            }
+        let timer = std::time::Instant::now();
+        let mutator_set_update = MutatorSetUpdate::compose(&block_mutations);
+        if block_mutations.len() > 1 {
+            info!(
+                "Composed mutator-set update to tip spanning {} blocks, with {} removals \
+                 and {} additions, in {:?}",
+                block_mutations.len(),
+                mutator_set_update.removals.len(),
+                mutator_set_update.additions.len(),
+                timer.elapsed(),
+            );
         }
 
-        let (mut addition_records, mut removal_records): (
-            Vec<Vec<AdditionRecord>>,
-            Vec<Vec<RemovalRecord>>,
-        ) = block_mutations.clone().into_iter().unzip();
-
-        addition_records.reverse();
-        removal_records.reverse();
-
-        let addition_records = addition_records.concat();
-        let mut removal_records = removal_records.concat();
-
-        let swbf_length = self.archival_mutator_set.ams().chunks.len().await;
-        for rr in &mut removal_records {
-            let mut removals = vec![];
-            for (chkidx, (mp, chunk)) in rr
-                .target_chunks
-                .chunk_indices_and_membership_proofs_and_leafs_iter_mut()
-            {
-                if swbf_length <= *chkidx {
-                    removals.push(*chkidx);
-                } else {
-                    *mp = self
-                        .archival_mutator_set
-                        .ams()
-                        .swbf_inactive
-                        .prove_membership_async(*chkidx)
-                        .await;
-                    *chunk = self.archival_mutator_set.ams().chunks.get(*chkidx).await;
-                }
-            }
-
-            for remove in removals {
-                rr.target_chunks.retain(|(x, _)| *x != remove);
-            }
-        }
-
-        self.archival_mutator_set.drop_unpersisted().await;
-
-        Some((
-            old_msa,
-            MutatorSetUpdate::new(removal_records, addition_records),
-        ))
+        Some((old_msa, mutator_set_update))
     }
 
     /// Returns the old mutator set matching the provided digest as well as the
@@ -1242,7 +1197,7 @@ impl ArchivalState {
     /// max search depth, as it loads all the blocks in the search path into
     /// memory. A max search depth of 0 means that only the tip is checked.
     pub(crate) async fn old_mutator_set_and_mutator_set_update_to_tip(
-        &mut self,
+        &self,
         old_mutator_set_digest: Digest,
         max_search_depth: usize,
     ) -> Option<(MutatorSetAccumulator, MutatorSetUpdate)> {
@@ -1259,7 +1214,7 @@ impl ArchivalState {
     /// max search depth, as it loads all the blocks in the search path into
     /// memory. A max search depth of 0 means that only the tip is checked.
     pub(crate) async fn get_mutator_set_update_to_tip(
-        &mut self,
+        &self,
         mutator_set: &MutatorSetAccumulator,
         max_search_depth: usize,
     ) -> Option<MutatorSetUpdate> {
@@ -1534,6 +1489,7 @@ pub(super) mod tests {
     use crate::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::archival::add_block_to_archival_state;
     use crate::tests::shared::archival::mock_genesis_archival_state;
+    use crate::tests::shared::blocks::block_with_num_puts;
     use crate::tests::shared::blocks::invalid_block_with_transaction;
     use crate::tests::shared::blocks::invalid_empty_block;
     use crate::tests::shared::blocks::make_mock_block;
@@ -3018,12 +2974,40 @@ pub(super) mod tests {
         }
 
         // Walking the opposite way returns None, and does not crash.
-        let mut genesis_archival_state = make_test_archival_state(network).await;
+        let genesis_archival_state = make_test_archival_state(network).await;
         for i in 0..10 {
             assert!(genesis_archival_state
                 .get_mutator_set_update_to_tip(&current_msa, i)
                 .await
                 .is_none());
+        }
+    }
+
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn ms_update_to_tip_across_removal_records() {
+        let network = Network::Main;
+        let mut archival_state = make_test_archival_state(network).await;
+
+        let genesis = Block::genesis(network);
+        let mut msas = vec![genesis.mutator_set_accumulator_after().unwrap()];
+        let mut current_block = genesis;
+
+        // The first block only adds, but enough to slide the mutator-set
+        // window; the following blocks remove UTXOs too.
+        for (num_inputs, num_outputs) in [(0, 32), (5, 33), (7, 58), (3, 0), (5, 104)] {
+            let next_block =
+                block_with_num_puts(network, &current_block, num_inputs, num_outputs).await;
+            add_block_to_archival_state(&mut archival_state, next_block.clone())
+                .await
+                .unwrap();
+            msas.push(next_block.mutator_set_accumulator_after().unwrap());
+            current_block = next_block;
+        }
+
+        let search_depth = 10;
+        for past_msa in &msas {
+            positive_prop_ms_update_to_tip(past_msa, &mut archival_state, search_depth).await;
         }
     }
 

--- a/xnt-core/src/state/archival_state.rs
+++ b/xnt-core/src/state/archival_state.rs
@@ -528,6 +528,28 @@ impl ArchivalState {
         self.write_block_internal(new_block, true).await
     }
 
+    /// Ensure internal consistency of archival state.
+    ///
+    /// Ensure that the entire archival state agrees with the tip defined by the
+    /// block index database and the block it points to on disk.
+    ///
+    /// Only intended to be run on startup, to recover from a non-graceful
+    /// shutdown. It fixes the state produced when the node is killed after the
+    /// block index database has been updated and the block written to disk, but
+    /// before the block MMR and mutator set updates finished.
+    ///
+    /// The sub-parts already handle roll-back and reorganization, so replaying
+    /// the tip update is sufficient to bring them all back into agreement.
+    pub(crate) async fn recover(&mut self) -> Result<()> {
+        let tip = self.get_tip().await;
+
+        self.write_block_as_tip(&tip).await?;
+        self.append_to_archival_block_mmr(&tip).await;
+        self.update_mutator_set(&tip).await?;
+
+        Ok(())
+    }
+
     /// Sets a block as tip for the archival block MMR.
     ///
     /// This method handles reorganizations, but all predecessors of this block
@@ -1513,6 +1535,7 @@ pub(super) mod tests {
     use crate::tests::shared::archival::add_block_to_archival_state;
     use crate::tests::shared::archival::mock_genesis_archival_state;
     use crate::tests::shared::blocks::invalid_block_with_transaction;
+    use crate::tests::shared::blocks::invalid_empty_block;
     use crate::tests::shared::blocks::make_mock_block;
     use crate::tests::shared::files::unit_test_data_directory;
     use crate::tests::shared::globalstate::mock_genesis_global_state;
@@ -1600,6 +1623,66 @@ pub(super) mod tests {
                     .await
             );
         }
+
+        Ok(())
+    }
+
+    /// `recover` must repair the state left by a non-graceful shutdown, and be
+    /// a no-op on a state that is already consistent.
+    ///
+    /// The crash simulated here is the one the method exists for: the block
+    /// index database has been advanced to a new tip and the block written to
+    /// disk, but the process died before the block MMR and the mutator set were
+    /// brought along.
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn recover_repairs_partially_applied_tip() -> Result<()> {
+        let network = Network::Main;
+        let mut archival_state = make_test_archival_state(network).await;
+        let genesis = archival_state.genesis_block.clone();
+
+        // Consistent to begin with, and `recover` must not disturb that.
+        assert_eq!(
+            genesis.hash(),
+            archival_state.archival_mutator_set.get_sync_label()
+        );
+        archival_state.recover().await?;
+        assert_eq!(
+            genesis.hash(),
+            archival_state.archival_mutator_set.get_sync_label(),
+            "recover must be a no-op on an already-consistent state"
+        );
+        let leafs_before = archival_state.archival_block_mmr.ammr().num_leafs().await;
+
+        // Simulate the crash: advance the tip only, leaving the block MMR and
+        // the mutator set behind.
+        let block1 = invalid_empty_block(&genesis, network);
+        archival_state.write_block_as_tip(&block1).await?;
+
+        assert_eq!(block1.hash(), archival_state.get_tip().await.hash());
+        assert_eq!(
+            genesis.hash(),
+            archival_state.archival_mutator_set.get_sync_label(),
+            "test premise: the mutator set must still lag the new tip"
+        );
+        assert_eq!(
+            leafs_before,
+            archival_state.archival_block_mmr.ammr().num_leafs().await,
+            "test premise: the block MMR must still lag the new tip"
+        );
+
+        archival_state.recover().await?;
+
+        assert_eq!(
+            block1.hash(),
+            archival_state.archival_mutator_set.get_sync_label(),
+            "recover must bring the mutator set up to the tip"
+        );
+        assert_eq!(
+            leafs_before + 1,
+            archival_state.archival_block_mmr.ammr().num_leafs().await,
+            "recover must bring the block MMR up to the tip"
+        );
 
         Ok(())
     }
@@ -4086,7 +4169,6 @@ pub(super) mod tests {
 
     mod block_hash_witness {
         use super::*;
-        use crate::tests::shared::blocks::invalid_empty_block;
 
         #[traced_test]
         #[apply(shared_tokio_runtime)]

--- a/xnt-core/src/state/archival_state.rs
+++ b/xnt-core/src/state/archival_state.rs
@@ -1889,7 +1889,7 @@ pub(super) mod tests {
         let mut alice = mock_genesis_global_state(42, alice_wallet, cli_args).await;
         let genesis_block = Block::genesis(network);
 
-        let num_premine_utxos = Block::premine_utxos().len();
+        let num_premine_utxos = Block::premine_utxos(network).len();
 
         let outputs = (0..20)
             .map(|_| {
@@ -1991,7 +1991,7 @@ pub(super) mod tests {
         let cli_args = cli_args::Args::default_with_network(network);
         let mut alice = mock_genesis_global_state(42, alice_wallet, cli_args).await;
 
-        let mut expected_num_utxos = Block::premine_utxos().len();
+        let mut expected_num_utxos = Block::premine_utxos(network).len();
         let mut previous_block = genesis_block.clone();
 
         let outputs = (0..20)
@@ -3111,7 +3111,7 @@ pub(super) mod tests {
         ] {
             let archival_state = make_test_archival_state(network).await;
             let genesis_block_digest = archival_state.genesis_block().hash();
-            let num_premine_outputs = Block::premine_utxos().len() as u64;
+            let num_premine_outputs = Block::premine_utxos(network).len() as u64;
 
             // Verify correct result for all premine outputs
             for aocl_leaf_index in 0..num_premine_outputs {

--- a/xnt-core/src/state/mempool.rs
+++ b/xnt-core/src/state/mempool.rs
@@ -56,6 +56,7 @@ use crate::api::export::NeptuneProof;
 use crate::application::config::tx_upgrade_filter::TxUpgradeFilter;
 use crate::protocol::consensus::block::block_height::BlockHeight;
 use crate::protocol::consensus::block::Block;
+use crate::protocol::consensus::consensus_rule_set::ConsensusRuleSet;
 use crate::protocol::consensus::transaction::primitive_witness::PrimitiveWitness;
 use crate::protocol::consensus::transaction::transaction_kernel::TransactionKernel;
 use crate::protocol::consensus::transaction::validity::neptune_proof::Proof;
@@ -1029,12 +1030,30 @@ impl Mempool {
     ///
     /// Number of transactions returned can be capped by either size (measured
     /// in bytes), or by transaction count. The function guarantees that neither
-    /// of the specified limits will be exceeded.
+    /// of the specified limits will be exceeded. The total number of inputs,
+    /// outputs, and announcements across the returned transactions likewise
+    /// respects the caps imposed by the consensus rules, leaving room for the
+    /// coinbase transaction they are expected to be merged with.
     pub(crate) fn get_transactions_for_block_composition(
         &self,
+        consensus_rule_set: ConsensusRuleSet,
         mut remaining_storage: usize,
         max_num_txs: Option<usize>,
     ) -> Vec<Transaction> {
+        // Numbers of outputs and announcements reserved for the coinbase
+        // transaction that the returned transactions will be merged with. No
+        // reservation is needed for inputs, as a coinbase transaction has none.
+        const COINBASE_NUM_OUTPUTS_RESERVATION: usize = 128;
+        const COINBASE_NUM_ANNOUNCEMENTS_RESERVATION: usize = 128;
+
+        let mut remaining_num_inputs = consensus_rule_set.max_num_inputs();
+        let mut remaining_num_outputs = consensus_rule_set
+            .max_num_outputs()
+            .saturating_sub(COINBASE_NUM_OUTPUTS_RESERVATION);
+        let mut remaining_num_announcements = consensus_rule_set
+            .max_num_announcements()
+            .saturating_sub(COINBASE_NUM_ANNOUNCEMENTS_RESERVATION);
+
         let mut transactions = vec![];
 
         for (transaction_digest, _fee_density) in self.fee_density_iter() {
@@ -1053,6 +1072,16 @@ impl Mempool {
                     continue;
                 }
 
+                // Current transaction would push the block transaction over one
+                // of the consensus caps.
+                let kernel = &transaction_ptr.kernel;
+                if kernel.inputs.len() > remaining_num_inputs
+                    || kernel.outputs.len() > remaining_num_outputs
+                    || kernel.announcements.len() > remaining_num_announcements
+                {
+                    continue;
+                }
+
                 let transaction_copy = transaction_ptr.to_owned();
                 let transaction_size = transaction_copy.get_size();
 
@@ -1063,6 +1092,9 @@ impl Mempool {
 
                 // Include transaction
                 remaining_storage -= transaction_size;
+                remaining_num_inputs -= transaction_copy.kernel.inputs.len();
+                remaining_num_outputs -= transaction_copy.kernel.outputs.len();
+                remaining_num_announcements -= transaction_copy.kernel.announcements.len();
                 transactions.push(transaction_copy)
             }
         }
@@ -1949,7 +1981,7 @@ mod tests {
         let max_fee_density: FeeDensity = FeeDensity::new(BigInt::from(u128::MAX), BigInt::from(1));
         let mut prev_fee_density = max_fee_density;
         for curr_transaction in
-            mempool.get_transactions_for_block_composition(SIZE_20MB_IN_BYTES, None)
+            mempool.get_transactions_for_block_composition(ConsensusRuleSet::default(), SIZE_20MB_IN_BYTES, None)
         {
             let curr_fee_density = curr_transaction.fee_density();
             assert!(curr_fee_density <= prev_fee_density);
@@ -1971,7 +2003,7 @@ mod tests {
 
         for num_mergers in 0..=num_txs_in_mempool {
             let returned_transactions = mempool
-                .get_transactions_for_block_composition(SIZE_20MB_IN_BYTES, Some(num_mergers));
+                .get_transactions_for_block_composition(ConsensusRuleSet::default(), SIZE_20MB_IN_BYTES, Some(num_mergers));
             assert_eq!(num_mergers, returned_transactions.len());
 
             let max_fee_density: FeeDensity =
@@ -2077,7 +2109,7 @@ mod tests {
             assert_eq!(
                 i,
                 mempool
-                    .get_transactions_for_block_composition(SIZE_20MB_IN_BYTES, Some(i))
+                    .get_transactions_for_block_composition(ConsensusRuleSet::default(), SIZE_20MB_IN_BYTES, Some(i))
                     .len()
             );
         }
@@ -2107,7 +2139,7 @@ mod tests {
 
             let max_total_tx_size = 1_000_000_000;
             let txs_returned =
-                mempool.get_transactions_for_block_composition(max_total_tx_size, None);
+                mempool.get_transactions_for_block_composition(ConsensusRuleSet::default(), max_total_tx_size, None);
             assert_eq!(
                 0,
                 txs_returned.len(),
@@ -2125,7 +2157,7 @@ mod tests {
             assert_eq!(
                 i,
                 mempool
-                    .get_transactions_for_block_composition(max_total_tx_size, None)
+                    .get_transactions_for_block_composition(ConsensusRuleSet::default(), max_total_tx_size, None)
                     .len(),
                 "Must return {i}/{i} transaction when mutator set hashes do match"
             );
@@ -2351,7 +2383,7 @@ mod tests {
         // updated and valid-again mutator set data
         let block2_msa = block_2.mutator_set_accumulator_after().unwrap();
         let mut tx_by_alice_updated: Transaction =
-            mempool.get_transactions_for_block_composition(usize::MAX, None)[0].clone();
+            mempool.get_transactions_for_block_composition(ConsensusRuleSet::default(), usize::MAX, None)[0].clone();
         assert!(
             tx_by_alice_updated.is_confirmable_relative_to(&block2_msa),
             "Block with tx with updated mutator set data must be confirmable wrt. block_2"
@@ -2375,7 +2407,7 @@ mod tests {
         }
 
         tx_by_alice_updated =
-            mempool.get_transactions_for_block_composition(usize::MAX, None)[0].clone();
+            mempool.get_transactions_for_block_composition(ConsensusRuleSet::default(), usize::MAX, None)[0].clone();
         let block_5_timestamp = previous_block.header().timestamp + Timestamp::hours(1);
         let (cbtx, _eutxo) = make_coinbase_transaction_from_state(
             &alice
@@ -2735,7 +2767,7 @@ mod tests {
                 .lock_guard()
                 .await
                 .mempool
-                .get_transactions_for_block_composition(usize::MAX, None);
+                .get_transactions_for_block_composition(ConsensusRuleSet::default(), usize::MAX, None);
             assert_eq!(
                 1,
                 mempool_txs.len(),
@@ -2784,7 +2816,7 @@ mod tests {
                 .lock_guard()
                 .await
                 .mempool
-                .get_transactions_for_block_composition(usize::MAX, None)
+                .get_transactions_for_block_composition(ConsensusRuleSet::default(), usize::MAX, None)
                 .iter()
                 .all(|tx| tx.is_confirmable_relative_to(
                     &block_1b.mutator_set_accumulator_after().unwrap(),
@@ -2938,7 +2970,7 @@ mod tests {
 
         assert!(!mempool.is_empty());
         assert!(mempool
-            .get_transactions_for_block_composition(usize::MAX, None)
+            .get_transactions_for_block_composition(ConsensusRuleSet::default(), usize::MAX, None)
             .is_empty());
     }
 

--- a/xnt-core/src/state/mempool.rs
+++ b/xnt-core/src/state/mempool.rs
@@ -198,6 +198,19 @@ pub struct Mempool {
     /// called and can shrink when [`Self::update_with_block`] is called.
     merge_input_cache: MergeInputCache,
 
+    /// Transactions whose proof upgrade was attempted and failed since the
+    /// last block.
+    ///
+    /// Proof upgrade candidate selection is deterministic, so a transaction
+    /// whose upgrade fails is picked again on every following attempt, and no
+    /// other transaction behind it is ever upgraded. Recording the failure
+    /// keeps the upgrader moving and gives other txs a chance. Cleared whenever
+    /// a new block is processed such that a transient failure doesn't prevent
+    /// the transaction from ever being upgraded. A transaction is never dropped
+    /// on account of upgrade failures.
+    #[get_size(ignore)]
+    upgrade_failures: HashSet<TransactionKernelId>,
+
     /// Recent mempool events. Keeps last N batches in memory only.
     #[get_size(ignore)]
     event_log: VecDeque<MempoolEventBatch>,
@@ -245,9 +258,23 @@ impl Mempool {
             tip_mutator_set_hash,
             tx_proving_capability,
             merge_input_cache,
+            upgrade_failures: HashSet::default(),
             event_log: VecDeque::new(),
             pending_abandoned: Vec::new(),
         }
+    }
+
+    /// Record that upgrading the proofs of these transactions failed, so that
+    /// they are passed over when picking the next upgrade candidate.
+    ///
+    /// The transactions are not removed, and the record is discarded by
+    /// [`Self::update_with_block`], so a failure that was transient only delays
+    /// an upgrade by one block.
+    pub(super) fn record_upgrade_failure(
+        &mut self,
+        txids: impl IntoIterator<Item = TransactionKernelId>,
+    ) {
+        self.upgrade_failures.extend(txids);
     }
 
     /// Update mempool with chain information.
@@ -336,6 +363,10 @@ impl Mempool {
             .chain(self.fee_density_iter().map(|(txid, _)| txid))
         {
             let candidate = self.tx_dictionary.get(&candidate_txid).unwrap();
+            if self.upgrade_failures.contains(&candidate_txid) {
+                continue;
+            }
+
             if self.tx_is_synced(&candidate.transaction.kernel) {
                 continue;
             }
@@ -389,6 +420,10 @@ impl Mempool {
             .chain(self.fee_density_iter().map(|(txid, _)| txid))
         {
             let candidate = self.tx_dictionary.get(&candidate_txid).unwrap();
+            if self.upgrade_failures.contains(&candidate_txid) {
+                continue;
+            }
+
             if !self.tx_is_synced(&candidate.transaction.kernel) {
                 continue;
             }
@@ -441,6 +476,10 @@ impl Mempool {
             .chain(self.fee_density_iter().map(|(txid, _)| txid))
         {
             let candidate = self.tx_dictionary.get(&candidate_txid).unwrap();
+
+            if self.upgrade_failures.contains(&candidate_txid) {
+                continue;
+            }
 
             if !self.tx_is_synced(&candidate.transaction.kernel) {
                 continue;
@@ -1182,6 +1221,10 @@ impl Mempool {
         &mut self,
         new_block: &Block,
     ) -> anyhow::Result<(Vec<MempoolEvent>, Vec<MempoolUpdateJob>)> {
+        // Ensure transactions are not permanently blocked on transient upgrade
+        // failures.
+        self.upgrade_failures.clear();
+
         // If the mempool is empty, there is nothing to do.
         if self.is_empty() && self.merge_input_cache.is_empty() {
             self.set_sync_labels(new_block)?;
@@ -1515,6 +1558,67 @@ mod tests {
                 .get_mut(&transaction_id)
                 .map(|x| &mut x.transaction)
         }
+    }
+
+    #[traced_test]
+    #[test]
+    fn failed_upgrade_lets_the_next_upgrade_candidate_through() {
+        let network = Network::Main;
+        let genesis_block = Block::genesis(network);
+        let mutator_set_hash = genesis_block
+            .mutator_set_accumulator_after()
+            .unwrap()
+            .hash();
+
+        let mut mempool = Mempool::new(
+            ByteSize::gb(1),
+            TxProvingCapability::SingleProof,
+            &genesis_block,
+        );
+        for mut tx in make_plenty_mock_transaction_supported_by_primitive_witness(2) {
+            tx.kernel = TransactionKernelModifier::default()
+                .mutator_set_hash(mutator_set_hash)
+                .modify(tx.kernel);
+            tx.proof = TransactionProof::ProofCollection(ProofCollection::invalid());
+            mempool.insert(tx, UpgradePriority::Irrelevant, AddReason::Submitted);
+        }
+        assert_eq!(2, mempool.len(), "sanity: two distinct candidates");
+
+        let preferred = |pool: &Mempool| {
+            pool.preferred_proof_collection(usize::MAX, TxUpgradeFilter::match_all())
+                .map(|(kernel, _, _)| kernel.txid())
+        };
+
+        let first = preferred(&mempool).expect("sanity: a candidate must be picked");
+        mempool.record_upgrade_failure([first]);
+
+        let second = preferred(&mempool)
+            .expect("a transaction whose upgrade failed must not block the next candidate");
+        assert_ne!(
+            first, second,
+            "the failed candidate must not be picked again"
+        );
+
+        mempool.record_upgrade_failure([second]);
+        assert!(
+            preferred(&mempool).is_none(),
+            "no candidate remains once every transaction's upgrade has failed"
+        );
+
+        // A new block gives every transaction another chance. In this fork a
+        // block also kicks witness-less proof-collection transactions from the
+        // mempool, so check the failure record directly rather than through
+        // candidate selection.
+        let block1 = invalid_empty_block_with_timestamp(
+            &genesis_block,
+            genesis_block.header().timestamp + Timestamp::hours(1),
+            network,
+        );
+        mempool.update_with_block(&block1).unwrap();
+        assert!(
+            mempool.upgrade_failures.is_empty(),
+            "a new block must clear the recorded upgrade failures"
+        );
     }
 
     #[apply(shared_tokio_runtime)]

--- a/xnt-core/src/state/mempool.rs
+++ b/xnt-core/src/state/mempool.rs
@@ -695,6 +695,25 @@ impl Mempool {
                 .get(&txid)
                 .and_then(|tx| tx.primitive_witness.clone())
         };
+
+        // A transaction's upgrade priority reflects our financial interest in
+        // seeing it confirmed, and that interest does not vanish when the
+        // transaction is superseded. A copy that reaches us over the wire is
+        // inserted with `Irrelevant` priority — whether it's our own
+        // transaction gossiped back, or, more importantly, a third party's
+        // merge that folded our inputs and outputs into a larger transaction.
+        // A merge carries a *new* txid, but it still conflicts with (and, when
+        // inserted below, kicks out) our original transaction. So the inserted
+        // transaction must inherit at least the highest priority among the
+        // conflicts it replaces; otherwise the mempool would stop
+        // mutator-set-updating the transaction carrying our funds. Compute this
+        // before the conflicting transactions are removed below.
+        let priority = conflicts
+            .keys()
+            .filter_map(|conflicting_txid| self.tx_dictionary.get(conflicting_txid))
+            .map(|conflicting| conflicting.upgrade_priority)
+            .fold(priority, |acc, conflicting| acc.max(conflicting));
+
         let new_tx = MempoolTransaction {
             transaction: new_tx,
             upgrade_priority: priority,
@@ -3857,6 +3876,105 @@ mod tests {
                     updated_tx.kernel.mutator_set_hash
                 ),
                 "Must return false on original after insertion of updated tx"
+            );
+        }
+
+        /// Regression test: a transaction inserted with a *lower* priority that
+        /// kicks out higher-priority conflicts must inherit their priority.
+        ///
+        /// The motivating case: we initiate transaction `a` (`Critical`). A
+        /// third party merges `a` with their own transaction `b` into `c`. `c`
+        /// carries our inputs and outputs (so it conflicts with, and replaces,
+        /// `a`) but has a *new* txid and reaches us over the wire as
+        /// `Irrelevant`. If `c` kept `Irrelevant`, the mempool would stop
+        /// mutator-set-updating the transaction that now carries our funds
+        /// (both `update_with_block` and `preferred_update` gate updating single
+        /// proofs on the stored `Critical` priority).
+        #[proptest(cases = 15, async = "tokio")]
+        async fn merge_received_over_wire_inherits_replaced_priority(
+            #[strategy(1usize..10)] _num_inputs_own: usize,
+            #[strategy(1usize..10)] _num_outputs_own: usize,
+            #[strategy(1usize..10)] _num_inputs_foreign: usize,
+            #[strategy(1usize..10)] _num_outputs_foreign: usize,
+            #[strategy(PrimitiveWitness::arbitrary_tuple_with_matching_mutator_sets(
+            [(#_num_inputs_own, #_num_outputs_own, 0),
+            (#_num_inputs_foreign, #_num_outputs_foreign, 0),],
+    ))]
+            pws: [PrimitiveWitness; 2],
+        ) {
+            // Transactions in the mempool do not need to be valid, so we just
+            // pretend that the primitive-witness backed transactions have a
+            // SingleProof. Skip cases where the (arbitrary) mutator set happens
+            // to match the genesis tip, so the transactions count as unsynced.
+            let genesis_block = Block::genesis(Network::Main);
+            let genesis_ms_hash = genesis_block
+                .mutator_set_accumulator_after()
+                .unwrap()
+                .hash();
+            let [own_pw, foreign_pw] = pws;
+            prop_assume!(own_pw.kernel.mutator_set_hash != genesis_ms_hash);
+
+            // Our transaction, with a small fee.
+            let own_kernel = TransactionKernelModifier::default()
+                .fee(NativeCurrencyAmount::from_nau(1))
+                .modify(own_pw.kernel);
+            let own_tx = Transaction {
+                kernel: own_kernel.clone(),
+                proof: TransactionProof::invalid(),
+            };
+
+            // A third party's merge of our transaction with theirs: it carries
+            // both parties' inputs and outputs (so it conflicts with `own_tx`),
+            // a large combined fee (so it wins the fee-density replacement), and
+            // therefore a new txid.
+            let merged_kernel = TransactionKernelModifier::default()
+                .inputs([own_kernel.inputs.clone(), foreign_pw.kernel.inputs.clone()].concat())
+                .outputs(
+                    [
+                        own_kernel.outputs.clone(),
+                        foreign_pw.kernel.outputs.clone(),
+                    ]
+                    .concat(),
+                )
+                .fee(NativeCurrencyAmount::coins(1))
+                .modify(own_kernel);
+            let merged_tx = Transaction {
+                kernel: merged_kernel,
+                proof: TransactionProof::invalid(),
+            };
+            prop_assert_ne!(own_tx.kernel.txid(), merged_tx.kernel.txid());
+
+            let mut mempool = Mempool::new(
+                ByteSize::gb(1),
+                TxProvingCapability::SingleProof,
+                &genesis_block,
+            );
+
+            // We initiated `own_tx`, so it enters the mempool as `Critical`.
+            mempool.insert(own_tx.clone(), UpgradePriority::Critical, AddReason::Submitted);
+
+            // The merge arrives over the wire as `Irrelevant`. It kicks out
+            // `own_tx` (shared inputs, higher combined fee density) ...
+            mempool.insert(merged_tx.clone(), UpgradePriority::Irrelevant, AddReason::Submitted);
+            prop_assert!(
+                !mempool.contains(own_tx.kernel.txid()),
+                "merge must replace our transaction"
+            );
+            prop_assert!(mempool.contains(merged_tx.kernel.txid()));
+
+            // ... but must inherit our `Critical` interest so the mempool keeps
+            // mutator-set-updating the transaction carrying our funds. The
+            // transactions are unsynced relative to the genesis tip, so
+            // `preferred_update` returns the merge along with its stored
+            // priority.
+            let (returned_kernel, _, priority) = mempool
+                .preferred_update(TxUpgradeFilter::match_all())
+                .expect("unsynced single-proof tx must be returned for update");
+            prop_assert_eq!(returned_kernel.txid(), merged_tx.kernel.txid());
+            prop_assert_eq!(
+                UpgradePriority::Critical,
+                priority,
+                "merge that replaces a Critical tx must inherit its priority"
             );
         }
     }

--- a/xnt-core/src/state/mempool/upgrade_priority.rs
+++ b/xnt-core/src/state/mempool/upgrade_priority.rs
@@ -11,6 +11,8 @@ use crate::application::loops::main_loop::upgrade_incentive::UpgradeIncentive;
 #[cfg_attr(test, derive(serde::Serialize))]
 #[cfg_attr(any(test, feature = "arbitrary-impls"), derive(arbitrary::Arbitrary))]
 pub enum UpgradePriority {
+    /// This transaction was received from a 3rd party and does not have a
+    /// financial interest for this node operator.
     #[default]
     Irrelevant,
 

--- a/xnt-core/src/state/mod.rs
+++ b/xnt-core/src/state/mod.rs
@@ -2323,14 +2323,11 @@ impl GlobalState {
     /// Favors transactions based on upgrade priority first, fee density
     /// second.
     ///
-    /// Needs mutable state access because of how the mutator set update value
-    /// is calculated. Does not actually mutate any state.
-    ///
     /// Returns none if no transaction in the mempool is in need of upgrading
     /// or if transaction in need of upgrading does not provide enough
     /// incentive.
     pub(crate) async fn preferred_update_job_from_mempool(
-        &mut self,
+        &self,
         min_gobbling_fee: NativeCurrencyAmount,
         tx_upgrade_filter: TxUpgradeFilter,
     ) -> Option<UpdateMutatorSetDataJob> {
@@ -2408,14 +2405,14 @@ impl GlobalState {
     }
 
     pub(crate) async fn upgrade_proof_collection_job(
-        &mut self,
+        &self,
         kernel: TransactionKernel,
         proof: ProofCollection,
         upgrade_incentive: UpgradeIncentive,
     ) -> Result<ProofCollectionToSingleProof> {
         let msa_lookup_result = self
             .chain
-            .archival_state_mut()
+            .archival_state()
             .old_mutator_set_and_mutator_set_update_to_tip(
                 kernel.mutator_set_hash,
                 SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,
@@ -2440,14 +2437,14 @@ impl GlobalState {
     /// Does not perform any proof upgrading, only returns the witness data
     /// required to construct a synced single proof.
     pub(crate) async fn update_single_proof_job(
-        &mut self,
+        &self,
         old_kernel: TransactionKernel,
         old_proof: NeptuneProof,
         upgrade_incentive: UpgradeIncentive,
     ) -> Result<UpdateMutatorSetDataJob> {
         let msa_lookup_result = self
             .chain
-            .archival_state_mut()
+            .archival_state()
             .old_mutator_set_and_mutator_set_update_to_tip(
                 old_kernel.mutator_set_hash,
                 SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,

--- a/xnt-core/src/state/mod.rs
+++ b/xnt-core/src/state/mod.rs
@@ -2360,6 +2360,18 @@ impl GlobalState {
         self.wallet_state.handle_mempool_events(event).await;
     }
 
+    /// Record that upgrading the proofs of these transactions failed, so the
+    /// proof upgrader picks a different candidate next time.
+    ///
+    /// Produces no mempool events: nothing is removed, the transactions are
+    /// only passed over until the next block arrives.
+    pub(crate) fn mempool_record_upgrade_failure(
+        &mut self,
+        txids: impl IntoIterator<Item = TransactionKernelId>,
+    ) {
+        self.mempool.record_upgrade_failure(txids);
+    }
+
     /// clears all Tx from mempool and notifies wallet of changes.
     pub async fn mempool_clear(&mut self) {
         let tip_height = self.chain.light_state().header().height;

--- a/xnt-core/src/state/wallet/address/common.rs
+++ b/xnt-core/src/state/wallet/address/common.rs
@@ -184,18 +184,26 @@ pub fn bytes_to_bfes(bytes: &[u8]) -> Vec<BFieldElement> {
 
 /// Decodes a slice of BFieldElements to a vec of bytes. This method
 /// computes the inverse of `bytes_to_bfes`.
+///
+/// Fails if the number of bytes exceed 8*10^6.
 pub fn bfes_to_bytes(bfes: &[BFieldElement]) -> Result<Vec<u8>> {
+    const MAX_DECODED_LENGTH: usize = BFieldElement::BYTES * 1_000_000;
     ensure!(!bfes.is_empty(), "Cannot decode empty byte stream");
 
-    let length = bfes[0].value() as usize;
+    let claimed_length = bfes[0].value() as usize;
     ensure!(
-        length <= size_of_val(bfes),
+        claimed_length <= size_of_val(bfes),
         "Cannot decode byte stream shorter than length indicated. \
-        BFE slice length: {}, indicated byte stream length: {length}",
+        BFE slice length: {}, indicated byte stream length: {claimed_length}",
         bfes.len(),
     );
 
-    let mut bytes: Vec<u8> = Vec::with_capacity(length);
+    ensure!(
+        claimed_length <= MAX_DECODED_LENGTH,
+        "Claimed length must not exceed {MAX_DECODED_LENGTH}"
+    );
+
+    let mut bytes: Vec<u8> = Vec::with_capacity(claimed_length);
     let mut skip_top = false;
     for bfe in bfes.iter().skip(1) {
         let bfe_bytes = bfe.value().to_be_bytes();
@@ -212,7 +220,7 @@ pub fn bfes_to_bytes(bfes: &[BFieldElement]) -> Result<Vec<u8>> {
         }
     }
 
-    Ok(bytes[0..length].to_vec())
+    Ok(bytes[0..claimed_length].to_vec())
 }
 
 // note: copied from twenty_first::math::lattice::kem::shake256()
@@ -259,6 +267,16 @@ pub(super) mod tests {
 
             assert_eq!(byte_vec, bytes_again);
         }
+    }
+
+    #[test]
+    fn too_long_msg() {
+        let byte_vec: Vec<u8> = vec![0; 10_000_000];
+        let bfes = bytes_to_bfes(&byte_vec);
+        assert!(
+            bfes_to_bytes(&bfes).is_err(),
+            "Must fail if trying to decode too many bytes."
+        );
     }
 
     #[test]

--- a/xnt-core/src/state/wallet/mod.rs
+++ b/xnt-core/src/state/wallet/mod.rs
@@ -61,6 +61,7 @@ mod tests {
     use crate::protocol::proof_abstractions::timestamp::Timestamp;
     use crate::state::transaction::tx_creation_config::TxCreationConfig;
     use crate::state::transaction::tx_proving_capability::TxProvingCapability;
+    use crate::state::wallet::address::ReceivingAddress;
     use crate::state::wallet::expected_utxo::UtxoNotifier;
     use crate::state::wallet::secret_key_material::SecretKeyMaterial;
     use crate::state::wallet::transaction_output::TxOutput;
@@ -97,17 +98,33 @@ mod tests {
             let mut alice =
                 mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), &cli_args).await;
             let alice_wallet = get_monitored_utxos(&alice).await;
-            assert_eq!(
-                1,
-                alice_wallet.len(),
-                "Monitored UTXO list must contain premined UTXO at init, for premine-wallet"
-            );
 
-            let expected_utxo = Block::premine_utxos()[0].clone();
+            // Only non-mainnet networks allocate premine to the devnet wallet;
+            // mainnet's allocation is fixed and goes elsewhere.
+            let devnet_lock_script_hash = ReceivingAddress::from(
+                WalletEntropy::devnet_wallet()
+                    .nth_generation_spending_key(0)
+                    .to_address(),
+            )
+            .lock_script_hash();
+            let expected_utxos = Block::premine_utxos(network)
+                .into_iter()
+                .filter(|utxo| utxo.lock_script_hash() == devnet_lock_script_hash)
+                .collect_vec();
+
             assert_eq!(
-                expected_utxo, alice_wallet[0].utxo,
-                "Devnet wallet's monitored UTXO must match that from genesis block at initialization"
+                expected_utxos.len(),
+                alice_wallet.len(),
+                "{network}: monitored UTXO list must contain every premine UTXO the devnet \
+                 wallet owns, at init"
             );
+            for (expected_utxo, monitored) in expected_utxos.iter().zip(&alice_wallet) {
+                assert_eq!(
+                    *expected_utxo, monitored.utxo,
+                    "{network}: devnet wallet's monitored UTXO must match that from the genesis \
+                     block at initialization"
+                );
+            }
 
             let bob_wallet = WalletEntropy::new_pseudorandom(rng.random());
             let bob_wallet = mock_genesis_wallet_state(bob_wallet, &cli_args).await;
@@ -141,22 +158,26 @@ mod tests {
 
             let alice_mutxos = get_monitored_utxos(&alice).await;
             assert_eq!(
-                1,
+                expected_utxos.len(),
                 alice_mutxos.len(),
-                "monitored UTXOs must be 1 after applying N blocks not mined by wallet"
+                "{network}: monitored UTXO count must be unchanged after applying N blocks not \
+                 mined by wallet"
             );
 
-            let genesis_block_utxo = alice_mutxos[0].utxo.clone();
-            let ms_membership_proof = alice_mutxos[0]
-                .get_membership_proof_for_block(next_block.hash())
-                .unwrap();
-            assert!(
-                next_block
-                    .mutator_set_accumulator_after()
-                    .unwrap()
-                    .verify(Tip5::hash(&genesis_block_utxo), &ms_membership_proof),
-                "Membership proof must be valid after updating wallet state with generated blocks"
-            );
+            for mutxo in &alice_mutxos {
+                let genesis_block_utxo = mutxo.utxo.clone();
+                let ms_membership_proof = mutxo
+                    .get_membership_proof_for_block(next_block.hash())
+                    .unwrap();
+                assert!(
+                    next_block
+                        .mutator_set_accumulator_after()
+                        .unwrap()
+                        .verify(Tip5::hash(&genesis_block_utxo), &ms_membership_proof),
+                    "{network}: membership proof must be valid after updating wallet state with \
+                     generated blocks"
+                );
+            }
         }
     }
 

--- a/xnt-core/src/state/wallet/wallet_state.rs
+++ b/xnt-core/src/state/wallet/wallet_state.rs
@@ -5311,7 +5311,7 @@ pub(crate) mod tests {
                 .lock_guard()
                 .await
                 .mempool
-                .get_transactions_for_block_composition(1_000_000_000, None)[0]
+                .get_transactions_for_block_composition(ConsensusRuleSet::default(), 1_000_000_000, None)[0]
                 .clone();
 
             // create block ignoring that transaction. Rando has upgraded tx
@@ -5369,7 +5369,7 @@ pub(crate) mod tests {
                 .lock_guard()
                 .await
                 .mempool
-                .get_transactions_for_block_composition(10_000_000, None);
+                .get_transactions_for_block_composition(ConsensusRuleSet::default(), 10_000_000, None);
             assert_eq!(1, transactions_for_block.len());
             let upgraded_transaction = transactions_for_block[0].clone();
             let new_num_announcements = upgraded_transaction.kernel.announcements.len();

--- a/xnt-core/src/state/wallet/wallet_state.rs
+++ b/xnt-core/src/state/wallet/wallet_state.rs
@@ -407,7 +407,7 @@ impl WalletState {
             // Check if we are premine recipients, and add expected UTXOs if so.
             for premine_key in &premine_keys {
                 let own_receiving_address = premine_key.clone().to_address();
-                for utxo in Block::premine_utxos() {
+                for utxo in Block::premine_utxos(configuration.network()) {
                     if utxo.lock_script_hash() == own_receiving_address.lock_script_hash() {
                         wallet_state
                             .add_expected_utxo(ExpectedUtxo::new(
@@ -2228,7 +2228,7 @@ pub(crate) mod tests {
 
         let premine_utxo = {
             let wallet = &alice_global_lock.lock_guard().await.wallet_state;
-            Block::premine_utxos()
+            Block::premine_utxos(network)
                 .into_iter()
                 .find(|premine_utxo| wallet.can_unlock(premine_utxo))
                 .or_else(|| panic!())

--- a/xnt-core/src/state/wallet/wallet_state.rs
+++ b/xnt-core/src/state/wallet/wallet_state.rs
@@ -1910,9 +1910,8 @@ impl WalletState {
                     ));
                 }
             } else {
-                let any_mp = &mutxo.blockhash_to_membership_proof.iter().next().unwrap().1;
                 unsynced.push(WalletStatusElement::new(
-                    any_mp.aocl_leaf_index,
+                    mutxo.aocl_leaf_index,
                     utxo,
                     payment_id,
                 ));

--- a/xnt-core/src/tests/shared/blocks.rs
+++ b/xnt-core/src/tests/shared/blocks.rs
@@ -333,6 +333,61 @@ pub(crate) async fn make_mock_block_with_inputs_and_outputs(
     .await
 }
 
+/// Return a block with the specied number of inputs/outputs. Inputs and
+/// outputs are random. Also contains randomized composer rewards.
+///
+/// Does not have a valid proof, nor valid PoW. Not deterministic.
+pub(crate) async fn block_with_num_puts(
+    network: Network,
+    predecessor: &Block,
+    num_inputs: u128,
+    num_outputs: usize,
+) -> Block {
+    use crate::util_types::mutator_set::removal_record::absolute_index_set::AbsoluteIndexSet;
+    use crate::util_types::mutator_set::removal_record::chunk_dictionary::ChunkDictionary;
+    use crate::util_types::mutator_set::shared::CHUNK_SIZE;
+    use crate::util_types::mutator_set::shared::NUM_TRIALS;
+    use crate::util_types::mutator_set::shared::WINDOW_SIZE;
+
+    let mut rng = rand::rng();
+    let active_window_start = u128::from(
+        predecessor
+            .mutator_set_accumulator_after()
+            .unwrap()
+            .get_batch_index(),
+    ) * u128::from(CHUNK_SIZE);
+    let inputs = (0..num_inputs)
+        .map(|_| RemovalRecord {
+            absolute_indices: AbsoluteIndexSet::new(
+                (0..NUM_TRIALS)
+                    .map(|_| rng.random_range(u128::from(CHUNK_SIZE * 3)..u128::from(WINDOW_SIZE)))
+                    .map(|ri| ri + active_window_start)
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+            ),
+            target_chunks: ChunkDictionary::default(),
+        })
+        .collect::<Vec<_>>();
+
+    let outputs = (0..num_outputs)
+        .map(|_| AdditionRecord::new(rng.random()))
+        .collect::<Vec<_>>();
+
+    let (block, _) = make_mock_block_with_inputs_and_outputs(
+        predecessor,
+        inputs,
+        outputs,
+        None,
+        GenerationSpendingKey::derive_from_seed(rng.random()),
+        rng.random(),
+        network,
+    )
+    .await;
+
+    block
+}
+
 /// Create and store the next block including any transactions presently in the
 /// mempool.  The coinbase and guesser fee will go to our own wallet.
 ///

--- a/xnt-core/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/xnt-core/src/util_types/mutator_set/archival_mutator_set.rs
@@ -18,6 +18,7 @@ use super::removal_record::chunk_dictionary::ChunkDictionary;
 use super::removal_record::RemovalRecord;
 use super::shared::BATCH_SIZE;
 use super::shared::CHUNK_SIZE;
+use super::shared::WINDOW_SIZE;
 use crate::application::database::storage::storage_vec::traits::*;
 use crate::protocol::consensus::block::block_height::BlockHeight;
 use crate::util_types::archival_mmr::ArchivalMmr;
@@ -496,7 +497,15 @@ where
         let active_window_start = batch_index * u128::from(CHUNK_SIZE);
 
         if index >= active_window_start {
-            let relative_index = (index - active_window_start) as u32;
+            // Ensure index is actually inside the active window. If not, it
+            // is a future index. Index must be valid u32.
+            let Ok(relative_index) = u32::try_from(index - active_window_start) else {
+                return false;
+            };
+            if relative_index >= WINDOW_SIZE {
+                return false;
+            }
+
             self.swbf_active.contains(relative_index)
         } else {
             let chunk_index = (index / u128::from(CHUNK_SIZE)) as u64;
@@ -642,6 +651,18 @@ mod tests {
     use crate::util_types::mutator_set::shared::NUM_TRIALS;
     use crate::util_types::test_shared::mutator_set::empty_rusty_mutator_set;
     use crate::util_types::test_shared::mutator_set::mock_item_and_randomnesses;
+
+    #[apply(shared_tokio_runtime)]
+    async fn far_future_index_is_not_in_active_window() {
+        let mut rms = empty_rusty_mutator_set().await;
+        let ams = rms.ams_mut();
+        ams.swbf_active.insert(5);
+
+        assert!(ams.bloom_filter_contains(5).await);
+        assert!(!ams.bloom_filter_contains((1u128 << 32) + 5).await);
+        assert!(!ams.bloom_filter_contains((1u128 << 64) + 5).await);
+        assert!(!ams.bloom_filter_contains((1u128 << 96) + 5).await);
+    }
 
     #[apply(shared_tokio_runtime)]
     async fn archival_set_commitment_test() {

--- a/xnt-core/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/xnt-core/src/util_types/mutator_set/archival_mutator_set.rs
@@ -293,9 +293,9 @@ where
         Ok((chunk_auth_path, chunk))
     }
 
-    /// Restore membership_proof. If called on someone else's UTXO, this leaks privacy. In this case,
-    /// caller is better off using `get_aocl_authentication_path` and `get_chunk_and_auth_path` for the
-    /// relevant indices.
+    /// Restore membership_proof. If called on someone else's UTXO, this leaks
+    /// privacy. In this case, caller is better off using
+    /// `restore_membership_proof_privacy_preserving`.
     pub async fn restore_membership_proof(
         &self,
         item: Digest,

--- a/xnt-core/src/util_types/mutator_set/mutator_set_accumulator.rs
+++ b/xnt-core/src/util_types/mutator_set/mutator_set_accumulator.rs
@@ -103,6 +103,7 @@ impl MutatorSetAccumulator {
 
     /// Return the lowest and the highest chunk index that are represented in
     /// the active window, inclusive.
+    ///
     /// The returned limits are inclusive, i.e. they point to the chunk with
     /// the lowest chunk index and the chunk with the highest chunk index that
     /// are still contained in the active window.
@@ -110,7 +111,7 @@ impl MutatorSetAccumulator {
         let batch_index = self.get_batch_index();
         (
             batch_index,
-            batch_index + u64::from(WINDOW_SIZE / CHUNK_SIZE),
+            batch_index + u64::from(WINDOW_SIZE / CHUNK_SIZE) - 1,
         )
     }
 
@@ -665,11 +666,45 @@ mod tests {
     }
 
     #[test]
+    fn can_remove_rejects_index_one_past_the_active_window() {
+        let accumulator = MutatorSetAccumulator::default();
+        let active_window_start =
+            u128::from(accumulator.get_batch_index()) * u128::from(CHUNK_SIZE);
+        let last_index_in_window = active_window_start + u128::from(WINDOW_SIZE) - 1;
+        let first_index_past_window = active_window_start + u128::from(WINDOW_SIZE);
+
+        let removal_record = |index| RemovalRecord {
+            absolute_indices: AbsoluteIndexSet::new([index; NUM_TRIALS as usize]),
+            target_chunks: ChunkDictionary::empty(),
+        };
+
+        assert!(
+            accumulator.can_remove(&removal_record(0)),
+            "first index, not rejected"
+        );
+
+        assert!(
+            accumulator.can_remove(&removal_record(u128::from(WINDOW_SIZE) / 2)),
+            "middle index, not rejected"
+        );
+
+        assert!(
+            accumulator.can_remove(&removal_record(last_index_in_window)),
+            "the last index the active window can represent must be read, not rejected"
+        );
+
+        assert!(
+            !accumulator.can_remove(&removal_record(first_index_past_window)),
+            "an index past the active window must be rejected"
+        );
+    }
+
+    #[test]
     fn active_window_chunk_interval_unit_test() {
         let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
         let (start_empty, end_empty) = accumulator.active_window_chunk_interval();
         assert_eq!(0, start_empty);
-        assert_eq!(u64::from(WINDOW_SIZE / CHUNK_SIZE), end_empty);
+        assert_eq!(u64::from(WINDOW_SIZE / CHUNK_SIZE) - 1, end_empty);
 
         // Insert batch-size items and verify that a new batch interval is reported
         for _ in 0..BATCH_SIZE + 1 {
@@ -678,25 +713,28 @@ mod tests {
 
             let (start, end) = accumulator.active_window_chunk_interval();
             assert_eq!(0, start);
-            assert_eq!(u64::from(WINDOW_SIZE / CHUNK_SIZE), end);
+            assert_eq!(u64::from(WINDOW_SIZE / CHUNK_SIZE) - 1, end);
             accumulator.add(&addition_record);
         }
 
         let (start_final, end_final) = accumulator.active_window_chunk_interval();
         assert_eq!(1, start_final);
-        assert_eq!(u64::from(WINDOW_SIZE / CHUNK_SIZE) + 1, end_final);
+        assert_eq!(u64::from(WINDOW_SIZE / CHUNK_SIZE), end_final);
     }
 
-    #[proptest(cases = 10)]
+    #[proptest(cases = 20)]
     fn batch_index_and_active_window_chunk_interval_agree(
-        #[strategy(1u64..10u64 * u64::from(BATCH_SIZE))] num_insertions: u64,
+        #[strategy(1u64..20u64 * u64::from(BATCH_SIZE))] num_insertions: u64,
     ) {
         let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
         for _ in 0..num_insertions {
             let (start, end) = accumulator.active_window_chunk_interval();
             let batch_interval = accumulator.get_batch_index();
             prop_assert_eq!(batch_interval, start);
-            prop_assert_eq!(batch_interval + u64::from(WINDOW_SIZE / CHUNK_SIZE), end);
+            prop_assert_eq!(
+                batch_interval + u64::from(WINDOW_SIZE / CHUNK_SIZE) - 1,
+                end
+            );
 
             let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
             let addition_record = commit(item, sender_randomness, receiver_preimage.hash());

--- a/xnt-core/src/util_types/mutator_set/mutator_set_accumulator.rs
+++ b/xnt-core/src/util_types/mutator_set/mutator_set_accumulator.rs
@@ -186,40 +186,75 @@ impl MutatorSetAccumulator {
     /// if either the MMR membership proofs are unsynced, or if all its indices
     /// are already set, or if the chunk dictionary is missing entries.
     pub fn can_remove(&self, removal_record: &RemovalRecord) -> bool {
-        let mut have_absent_index = false;
+        self.can_remove_all(std::slice::from_ref(removal_record))
+    }
 
-        // Validate verifies that the all required chunk/MMR membership proof
-        // pairs are present, and that all MMR membership proofs are valid
-        // against the mutator set accumulator.
-        if !removal_record.validate(self) {
-            return false;
-        }
-
-        let swbfi_num_leafs = self.get_batch_index();
-        let active_window_start = u128::from(swbfi_num_leafs) * u128::from(CHUNK_SIZE);
-        for inserted_index in removal_record.absolute_indices.to_vec() {
-            // determine if inserted index lives in active window
-            if inserted_index < active_window_start {
-                let inserted_index_chunkidx = (inserted_index / u128::from(CHUNK_SIZE)) as u64;
-                let (_mmr_mp, chunk) = removal_record
-                    .target_chunks
-                    .get(&inserted_index_chunkidx)
-                    .expect("Presence of required MMR MPs should have already been established.");
-                let relative_index = (inserted_index % u128::from(CHUNK_SIZE)) as u32;
-                if !chunk.contains(relative_index) {
-                    have_absent_index = true;
-                    break;
-                }
-            } else {
-                let relative_index = (inserted_index - active_window_start) as u32;
-                if !self.swbf_active.contains(relative_index) {
-                    have_absent_index = true;
-                    break;
-                }
+    /// Check if a batch of removal records can be applied to a mutator set.
+    ///
+    /// Returns false if some removal record's MMR membership proofs are
+    /// unsynced or its chunk dictionary is missing entries, or if some
+    /// removal record contributes nothing: every removal record must have at
+    /// least one index that is neither set in the Bloom filter already nor
+    /// contributed by any other removal record in the batch.
+    ///
+    /// For a single removal record this coincides with [`Self::can_remove`].
+    /// For larger batches it is slightly stricter than checking
+    /// [`Self::can_remove`] for each record under sequential application:
+    /// sequential application accepts a record whose indices are covered by
+    /// the Bloom filter and *later* records combined. Unlike the sequential
+    /// check, this predicate is independent of the records' order.
+    pub fn can_remove_all(&self, removal_records: &[RemovalRecord]) -> bool {
+        // index -> multiplicity, over the entire batch
+        let mut combined_counts: HashMap<u128, u32> = HashMap::new();
+        for removal_record in removal_records {
+            for index in removal_record.absolute_indices.iter() {
+                *combined_counts.entry(index).or_default() += 1;
             }
         }
 
-        have_absent_index
+        let active_window_start = u128::from(self.get_batch_index()) * u128::from(CHUNK_SIZE);
+        removal_records.iter().all(|removal_record| {
+            // Validate verifies that the all required chunk/MMR membership
+            // proof pairs are present, and that all MMR membership proofs are
+            // valid against the mutator set accumulator.
+            if !removal_record.validate(self) {
+                return false;
+            }
+
+            let mut own_counts: HashMap<u128, u32> = HashMap::new();
+            for index in removal_record.absolute_indices.iter() {
+                *own_counts.entry(index).or_default() += 1;
+            }
+
+            own_counts.into_iter().any(|(inserted_index, own_count)| {
+                // An index contributed by another removal record in the batch
+                // counts as set.
+                // This checks compatibility with all other removal records in
+                // the list.
+                if combined_counts[&inserted_index] > own_count {
+                    return false;
+                }
+
+                // Determine if index was set prior to the application of these
+                // removal records.
+                if inserted_index < active_window_start {
+                    // Index lives in a chunk
+                    let inserted_index_chunkidx = (inserted_index / u128::from(CHUNK_SIZE)) as u64;
+                    let (_mmr_mp, chunk) = removal_record
+                        .target_chunks
+                        .get(&inserted_index_chunkidx)
+                        .expect(
+                            "Presence of required MMR MPs should have already been established.",
+                        );
+                    let relative_index = (inserted_index % u128::from(CHUNK_SIZE)) as u32;
+                    !chunk.contains(relative_index)
+                } else {
+                    // Index lives in the active window
+                    let relative_index = (inserted_index - active_window_start) as u32;
+                    !self.swbf_active.contains(relative_index)
+                }
+            })
+        })
     }
 }
 
@@ -556,6 +591,66 @@ mod tests {
         use super::*;
         use crate::protocol::consensus::block::mutator_set_update::MutatorSetUpdate;
         use crate::util_types::mutator_set::msa_and_records::MsaAndRecords;
+
+        #[test]
+        fn can_remove_all_requires_a_unique_unset_index_per_record() {
+            // All indices lie in the initial active window, so removal records
+            // with empty chunk dictionaries are valid.
+            fn removal_record(indices: [u128; NUM_TRIALS as usize]) -> RemovalRecord {
+                RemovalRecord {
+                    absolute_indices: AbsoluteIndexSet::new(indices),
+                    target_chunks: ChunkDictionary::default(),
+                }
+            }
+            fn indices_from(start: u128) -> [u128; NUM_TRIALS as usize] {
+                core::array::from_fn(|i| start + i as u128)
+            }
+
+            let mut msa = MutatorSetAccumulator::default();
+            let first = removal_record(indices_from(0));
+            let second = removal_record(indices_from(1000));
+
+            // Every record in a batch of disjoint records has unique indices.
+            assert!(msa.can_remove_all(&[]));
+            assert!(msa.can_remove_all(std::slice::from_ref(&first)));
+            assert!(msa.can_remove_all(&[first.clone(), second.clone()]));
+
+            // In a batch of two identical records, neither record has an
+            // index that the other does not also contribute.
+            assert!(!msa.can_remove_all(&[first.clone(), first.clone()]));
+
+            // A record's index multiplicity does not count against itself.
+            let self_repeating = removal_record([9000; NUM_TRIALS as usize]);
+            assert!(msa.can_remove_all(std::slice::from_ref(&self_repeating)));
+
+            // Indices set in the Bloom filter count as covered.
+            msa.remove(&first);
+            assert!(!msa.can_remove_all(std::slice::from_ref(&first)));
+            assert!(!msa.can_remove_all(&[first, second.clone()]));
+            assert!(msa.can_remove_all(std::slice::from_ref(&second)));
+
+            // A record whose indices are covered by the Bloom filter and
+            // another record *combined* invalidates the batch, even though
+            // each record passes the single-record check.
+            let covered = removal_record(core::array::from_fn(|i| {
+                if i < 20 {
+                    i as u128
+                } else {
+                    100 + (i as u128 - 20)
+                }
+            }));
+            let covering = removal_record(core::array::from_fn(|i| {
+                if i < 25 {
+                    100 + i as u128
+                } else {
+                    200 + (i as u128 - 25)
+                }
+            }));
+            assert!(msa.can_remove(&covered));
+            assert!(msa.can_remove(&covering));
+            assert!(!msa.can_remove_all(&[covered.clone(), covering.clone()]));
+            assert!(!msa.can_remove_all(&[covering, covered]));
+        }
 
         #[proptest]
         fn missing_chunk_dictionary_entry_small(

--- a/xnt-core/src/util_types/mutator_set/removal_record.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record.rs
@@ -29,7 +29,10 @@ use twenty_first::util_types::mmr::mmr_trait::Mmr;
 use super::mutator_set_accumulator::MutatorSetAccumulator;
 use super::removal_record::chunk_dictionary::ChunkDictionary;
 use super::shared::get_batch_mutation_argument_for_removal_record;
+use super::shared::get_batch_mutation_argument_for_removal_records;
 use super::shared::indices_to_hash_map;
+use super::shared::prepare_authenticated_batch_modification_for_removal_record_reversion;
+use super::shared::prepare_authenticated_batch_modification_for_removal_records_reversion;
 use super::shared::BATCH_SIZE;
 use super::shared::CHUNK_SIZE;
 use super::MutatorSetError;
@@ -197,6 +200,189 @@ impl RemovalRecord {
                 .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
                 .collect_vec(),
         );
+    }
+
+    /// Update a batch of removal records that are synced to a given mutator
+    /// set, in anticipation of the application of any number of removal
+    /// records.
+    ///
+    /// Equivalent to applying [`Self::batch_update_from_remove`] for each
+    /// applied removal record in turn — with the applied records themselves
+    /// kept in sync between applications — but performs only a single batch
+    /// mutation of the underlying MMR membership proofs. The combined
+    /// mutation is well-defined because the chunk modifications of the
+    /// individual applications commute.
+    ///
+    /// The applied removal records must be synced to the same mutator-set
+    /// state as the removal records being updated. The batch being updated
+    /// may contain copies of the applied records; such copies end up synced
+    /// to the state after the application of the entire batch, including
+    /// themselves.
+    pub fn batch_update_from_removals(
+        removal_records: &mut [&mut Self],
+        applied_removal_records: &[RemovalRecord],
+    ) {
+        // Set all chunk values to the new values and calculate the mutation argument
+        // for the batch updating of the MMR membership proofs.
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
+            .iter_mut()
+            .map(|rr| &mut rr.target_chunks)
+            .collect();
+        let (_mutated_chunks_by_rr_indices, mutation_argument) =
+            get_batch_mutation_argument_for_removal_records(
+                applied_removal_records,
+                &mut chunk_dictionaries,
+            );
+
+        // Collect all the MMR membership proofs from the chunk dictionaries.
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof> = vec![];
+        let mut leaf_indices = vec![];
+        for chunk_dict in &mut chunk_dictionaries {
+            for (chunk_index, (mp, _)) in chunk_dict.iter_mut() {
+                own_mmr_mps.push(mp);
+                leaf_indices.push(*chunk_index);
+            }
+        }
+
+        // Perform the batch mutation of the MMR membership proofs
+        mmr::mmr_membership_proof::MmrMembershipProof::batch_update_from_batch_leaf_mutation(
+            &mut own_mmr_mps,
+            &leaf_indices,
+            mutation_argument
+                .iter()
+                .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
+                .collect_vec(),
+        );
+    }
+
+    /// Revert a batch of removal records to their state prior to the
+    /// application of any number of removal records.
+    ///
+    /// Reverse of [`Self::batch_update_from_removals`]: applying that
+    /// function and then this one, with the same batch of applied removal
+    /// records, is the identity. Unlike
+    /// [`Self::batch_revert_update_from_remove`], which takes the reverted
+    /// record in its as-applied form, the reverted removal records here must
+    /// be synced to the same mutator-set state as the records being reverted
+    /// — the state after the application of the entire batch, including
+    /// themselves.
+    pub fn batch_revert_update_from_removals(
+        removal_records: &mut [&mut Self],
+        reverted_removal_records: &[RemovalRecord],
+    ) {
+        // Set all chunk values back to the old values and calculate the
+        // mutation argument for the batch updating of the MMR membership
+        // proofs.
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
+            .iter_mut()
+            .map(|rr| &mut rr.target_chunks)
+            .collect();
+        let (_mutated_chunks_by_rr_indices, mutation_argument) =
+            prepare_authenticated_batch_modification_for_removal_records_reversion(
+                reverted_removal_records,
+                &mut chunk_dictionaries,
+            );
+
+        // Collect all the MMR membership proofs from the chunk dictionaries.
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof> = vec![];
+        let mut leaf_indices = vec![];
+        for chunk_dict in &mut chunk_dictionaries {
+            for (chunk_index, (mp, _)) in chunk_dict.iter_mut() {
+                own_mmr_mps.push(mp);
+                leaf_indices.push(*chunk_index);
+            }
+        }
+
+        // Perform the batch mutation of the MMR membership proofs
+        mmr::mmr_membership_proof::MmrMembershipProof::batch_update_from_batch_leaf_mutation(
+            &mut own_mmr_mps,
+            &leaf_indices,
+            mutation_argument
+                .iter()
+                .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
+                .collect_vec(),
+        );
+    }
+
+    /// Revert a batch of removal records to their state prior to being
+    /// updated with the application of another removal record.
+    ///
+    /// Reverse of [`Self::batch_update_from_remove`]: applying that function
+    /// and then this one, with the same `reverted_removal_record`, is the
+    /// identity.
+    pub fn batch_revert_update_from_remove(
+        removal_records: &mut [&mut Self],
+        reverted_removal_record: &RemovalRecord,
+    ) {
+        // Set all chunk values back to the old values and calculate the
+        // mutation argument for the batch updating of the MMR membership
+        // proofs.
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
+            .iter_mut()
+            .map(|rr| &mut rr.target_chunks)
+            .collect();
+        let (_mutated_chunks_by_rr_indices, mutation_argument) =
+            prepare_authenticated_batch_modification_for_removal_record_reversion(
+                reverted_removal_record,
+                &mut chunk_dictionaries,
+            );
+
+        // Collect all the MMR membership proofs from the chunk dictionaries.
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof> = vec![];
+        let mut leaf_indices = vec![];
+        for chunk_dict in &mut chunk_dictionaries {
+            for (chunk_index, (mp, _)) in chunk_dict.iter_mut() {
+                own_mmr_mps.push(mp);
+                leaf_indices.push(*chunk_index);
+            }
+        }
+
+        // Perform the batch mutation of the MMR membership proofs
+        mmr::mmr_membership_proof::MmrMembershipProof::batch_update_from_batch_leaf_mutation(
+            &mut own_mmr_mps,
+            &leaf_indices,
+            mutation_argument
+                .iter()
+                .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
+                .collect_vec(),
+        );
+    }
+
+    /// Revert a batch of removal records to their state at a previous mutator
+    /// set accumulator, prior to being updated with one or more additions.
+    ///
+    /// The previous accumulator is identified by the number of leafs in its
+    /// inactive sliding-window Bloom filter, i.e. its batch index; nothing
+    /// else about it is needed.
+    ///
+    /// Reverse of [`Self::batch_update_from_addition`], but can revert any
+    /// number of additions in one call. Only additions may separate the
+    /// records' current state from the previous accumulator; removals in
+    /// between must be reverted with [`Self::batch_revert_update_from_remove`]
+    /// first.
+    pub fn batch_revert_update_from_addition(
+        removal_records: &mut [&mut Self],
+        previous_swbfi_leaf_count: u64,
+    ) {
+        for removal_record in removal_records.iter_mut() {
+            // Chunks that the reverted additions slid out of the active window
+            // have their dictionary entries removed.
+            removal_record
+                .target_chunks
+                .retain(|(chunk_index, _)| *chunk_index < previous_swbfi_leaf_count);
+
+            // Appending to an MMR only ever extends the authentication path of
+            // an existing leaf, so the appends are reverted by truncating each
+            // path back to the height of its leaf's Merkle tree in the
+            // previous MMR.
+            for (chunk_index, (mp, _chunk)) in removal_record.target_chunks.iter_mut() {
+                let chunk_discrepancies = previous_swbfi_leaf_count ^ *chunk_index;
+                let chunk_mt_height = u128::from(chunk_discrepancies).ilog2();
+                while mp.authentication_path.len() > chunk_mt_height as usize {
+                    mp.authentication_path.pop();
+                }
+            }
+        }
     }
 
     fn has_required_authenticated_chunks(
@@ -811,6 +997,188 @@ mod tests {
                     .unwrap()
             );
         }
+    }
+
+    #[test]
+    fn batch_revert_update_from_addition_round_trip() {
+        let num_additions = 4 * BATCH_SIZE + 4;
+        let mut accumulator = MutatorSetAccumulator::default();
+        let mut removal_records: Vec<RemovalRecord> = vec![];
+
+        // The (accumulator, removal records) state before each addition.
+        let mut snapshots: Vec<(MutatorSetAccumulator, Vec<RemovalRecord>)> = vec![];
+
+        for _ in 0..num_additions {
+            let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+            let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+
+            snapshots.push((accumulator.clone(), removal_records.clone()));
+
+            RemovalRecord::batch_update_from_addition(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &accumulator,
+            );
+            accumulator.add(&addition_record);
+
+            let removal_record = accumulator.drop(item, &mp);
+            removal_records.push(removal_record);
+        }
+
+        let final_records = removal_records.clone();
+
+        // Revert one addition at a time, all the way back to the empty
+        // mutator set, and verify that each step reproduces the recorded
+        // state exactly.
+        for (previous_accumulator, previous_removal_records) in snapshots.iter().rev() {
+            // The removal record born of this addition does not exist in the
+            // previous state.
+            removal_records.pop();
+
+            RemovalRecord::batch_revert_update_from_addition(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                previous_accumulator.swbf_inactive.num_leafs(),
+            );
+
+            assert_eq!(*previous_removal_records, removal_records);
+            for removal_record in &removal_records {
+                assert!(removal_record.validate(previous_accumulator));
+                assert!(previous_accumulator.can_remove(removal_record));
+            }
+        }
+
+        // Also revert many additions in one call: take the oldest removal
+        // record at the final state directly back to its birth state.
+        let (birth_accumulator, _) = &snapshots[1];
+        let mut oldest = final_records[0].clone();
+        RemovalRecord::batch_revert_update_from_addition(
+            &mut [&mut oldest],
+            birth_accumulator.swbf_inactive.num_leafs(),
+        );
+        assert_eq!(snapshots[1].1[0], oldest);
+        assert!(oldest.validate(birth_accumulator));
+    }
+
+    #[test]
+    fn batch_revert_update_from_remove_round_trip() {
+        let num_additions = 16 * BATCH_SIZE + 4;
+        let mut accumulator = MutatorSetAccumulator::default();
+        let mut removal_records: Vec<RemovalRecord> = vec![];
+
+        // Add all items, keeping all removal records in sync.
+        for _ in 0..num_additions {
+            let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+            let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+
+            RemovalRecord::batch_update_from_addition(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &accumulator,
+            );
+            accumulator.add(&addition_record);
+
+            let removal_record = accumulator.drop(item, &mp);
+            removal_records.push(removal_record);
+        }
+
+        // Apply half the removal records one at a time, keeping the rest in
+        // sync and recording the state before each removal.
+        let num_removals = num_additions as usize / 2;
+        let mut history = vec![];
+        for _ in 0..num_removals {
+            let remove_idx = rand::rng().random_range(0..removal_records.len());
+            let snapshot = (accumulator.clone(), removal_records.clone());
+            let applied = removal_records.remove(remove_idx);
+            RemovalRecord::batch_update_from_remove(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &applied,
+            );
+            accumulator.remove(&applied);
+            history.push((remove_idx, applied, snapshot));
+        }
+
+        // Revert one removal at a time and verify that each step reproduces
+        // the recorded state exactly. The applied record itself was not
+        // updated past its application, so re-inserting it restores the full
+        // record list.
+        for (remove_idx, applied, (snapshot_accumulator, snapshot_records)) in
+            history.into_iter().rev()
+        {
+            RemovalRecord::batch_revert_update_from_remove(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &applied,
+            );
+            removal_records.insert(remove_idx, applied);
+
+            assert_eq!(snapshot_records, removal_records);
+            for removal_record in &removal_records {
+                assert!(removal_record.validate(&snapshot_accumulator));
+                assert!(snapshot_accumulator.can_remove(removal_record));
+            }
+        }
+    }
+
+    #[test]
+    fn batch_removals_agree_with_sequential_application() {
+        let num_additions = 16 * BATCH_SIZE + 4;
+        let mut accumulator = MutatorSetAccumulator::default();
+        let mut all_records: Vec<RemovalRecord> = vec![];
+
+        // Add all items, keeping all removal records in sync.
+        for _ in 0..num_additions {
+            let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+            let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+
+            RemovalRecord::batch_update_from_addition(
+                &mut all_records.iter_mut().collect::<Vec<_>>(),
+                &accumulator,
+            );
+            accumulator.add(&addition_record);
+
+            all_records.push(accumulator.drop(item, &mp));
+        }
+
+        // The first `num_removals` records are applied; the rest are
+        // bystanders. `all_records` also keeps copies of the applied records
+        // themselves in sync, through their own application and past it.
+        let num_removals = 20;
+        let applied_records: Vec<RemovalRecord> = all_records[..num_removals].to_vec();
+        let pre_removal_records = all_records.clone();
+
+        // Sequential ground truth, applying one removal record at a time.
+        let mut seq_records = all_records.clone();
+        for i in 0..num_removals {
+            let applied = seq_records[i].clone();
+            RemovalRecord::batch_update_from_remove(
+                &mut seq_records.iter_mut().collect::<Vec<_>>(),
+                &applied,
+            );
+            assert!(accumulator.can_remove(&applied));
+            accumulator.remove(&applied);
+        }
+        for removal_record in &seq_records[num_removals..] {
+            assert!(removal_record.validate(&accumulator));
+            assert!(accumulator.can_remove(removal_record));
+        }
+
+        // The combined application must reproduce the sequential result
+        // exactly.
+        let mut batch_records = pre_removal_records.clone();
+        RemovalRecord::batch_update_from_removals(
+            &mut batch_records.iter_mut().collect::<Vec<_>>(),
+            &applied_records,
+        );
+        assert_eq!(seq_records, batch_records);
+
+        // The combined reversion, fed the applied records in their
+        // post-application form, must restore the pre-removal state exactly.
+        let post_removal_applied_forms = batch_records[..num_removals].to_vec();
+        RemovalRecord::batch_revert_update_from_removals(
+            &mut batch_records.iter_mut().collect::<Vec<_>>(),
+            &post_removal_applied_forms,
+        );
+        assert_eq!(pre_removal_records, batch_records);
     }
 
     proptest::proptest! {

--- a/xnt-core/src/util_types/mutator_set/removal_record.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record.rs
@@ -217,8 +217,8 @@ impl RemovalRecord {
     }
 
     /// Validates that a removal record is synchronized against the inactive
-    /// part of the SWBF, and that all required chunk/MMR membership proofs are
-    /// present.
+    /// part of the SWBF, and that the chunk/MMR membership proofs it carries
+    /// are exactly those its indices require, no fewer, and no more.
     pub fn validate(&self, mutator_set: &MutatorSetAccumulator) -> bool {
         self.validate_inner(mutator_set).is_ok()
     }
@@ -228,8 +228,15 @@ impl RemovalRecord {
         &self,
         mutator_set: &MutatorSetAccumulator,
     ) -> Result<(), RemovalRecordValidityError> {
+        // Disallow repeated chunk indices, since an (unpacked) removal record
+        // is supposed to be a map.
+        let chunk_indices = self.target_chunks.all_chunk_indices();
+        if let Some(&chunk_index) = chunk_indices.iter().duplicates().next() {
+            return Err(RemovalRecordValidityError::DuplicateChunkIndex { chunk_index });
+        }
+
         if !self.has_required_authenticated_chunks(mutator_set) {
-            return Err(RemovalRecordValidityError::AbsentAuthenticatedChunk);
+            return Err(RemovalRecordValidityError::MismatchedChunkIndices);
         }
 
         let swbfi_peaks = mutator_set.swbf_inactive.peaks();
@@ -258,8 +265,14 @@ impl RemovalRecord {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemovalRecordValidityError {
-    AbsentAuthenticatedChunk,
-    InvalidSwbfiMmrMp { chunk_index: u64 },
+    /// Missing or superfluous chunk indices compared to what's required.
+    MismatchedChunkIndices,
+    InvalidSwbfiMmrMp {
+        chunk_index: u64,
+    },
+    DuplicateChunkIndex {
+        chunk_index: u64,
+    },
 }
 
 #[cfg(test)]
@@ -462,6 +475,94 @@ mod tests {
 
         assert!(rr_for_aocl0.validate(&accumulator));
         assert!(!rr_for_aocl0.validate(&MutatorSetAccumulator::default()));
+    }
+
+    #[test]
+    fn duplicate_chunk_index_is_invalid() {
+        let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
+        let (min_index_in_active_window, max_index_in_active_window) =
+            accumulator.active_window_chunk_interval();
+        let num_chunks_in_active_window = max_index_in_active_window - min_index_in_active_window;
+
+        let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+        let addition_record: AdditionRecord =
+            commit(item, sender_randomness, receiver_preimage.hash());
+
+        let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+        accumulator.add(&addition_record);
+        let mut removal_record = accumulator.drop(item, &mp);
+
+        // Move every index into the inactive part of the sliding-window Bloom
+        // filter, so that the removal record has SWBF auth paths.
+        for _ in 0..u64::from(BATCH_SIZE) * num_chunks_in_active_window + 1 {
+            RemovalRecord::batch_update_from_addition(&mut [&mut removal_record], &accumulator);
+            accumulator.add(&addition_record);
+        }
+        assert!(removal_record.validate(&accumulator));
+        assert!(accumulator.can_remove(&removal_record));
+
+        let repeated_entry = removal_record.target_chunks.dictionary[0].clone();
+        let chunk_index = repeated_entry.0;
+        removal_record.target_chunks.dictionary.push(repeated_entry);
+
+        assert_eq!(
+            Err(RemovalRecordValidityError::DuplicateChunkIndex { chunk_index }),
+            removal_record.validate_inner(&accumulator)
+        );
+        assert!(
+            !accumulator.can_remove(&removal_record),
+            "a removal record with a repeated chunk index must not be applicable"
+        );
+    }
+
+    #[test]
+    fn superfluous_chunk_is_invalid() {
+        let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
+        let (min_index_in_active_window, max_index_in_active_window) =
+            accumulator.active_window_chunk_interval();
+        let num_chunks_in_active_window = max_index_in_active_window - min_index_in_active_window;
+
+        let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+        let addition_record: AdditionRecord =
+            commit(item, sender_randomness, receiver_preimage.hash());
+
+        let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+        accumulator.add(&addition_record);
+        let mut removal_record = accumulator.drop(item, &mp);
+
+        // Move every index into the inactive part of the sliding-window Bloom
+        // filter, so that the removal record has SWBF auth paths.
+        for _ in 0..u64::from(BATCH_SIZE) * num_chunks_in_active_window + 1 {
+            RemovalRecord::batch_update_from_addition(&mut [&mut removal_record], &accumulator);
+            accumulator.add(&addition_record);
+        }
+        assert!(removal_record.validate(&accumulator));
+
+        // Add an authenticated chunk for an index that none of the removal
+        // record's absolute indices points into.
+        let (unrequired_chunk_index, authenticated_chunk) = {
+            let (_, authenticated_chunk) = removal_record.target_chunks.dictionary[0].clone();
+            let not_required_chk_idx = removal_record
+                .target_chunks
+                .all_chunk_indices()
+                .into_iter()
+                .max()
+                .unwrap()
+                + 1;
+            (not_required_chk_idx, authenticated_chunk)
+        };
+        removal_record
+            .target_chunks
+            .insert(unrequired_chunk_index, authenticated_chunk);
+
+        assert_eq!(
+            Err(RemovalRecordValidityError::MismatchedChunkIndices),
+            removal_record.validate_inner(&accumulator)
+        );
+        assert!(
+            !accumulator.can_remove(&removal_record),
+            "a removal record with a superfluous chunk must not be applicable"
+        );
     }
 
     /// non-deterministic; a correction was shelved at <https://github.com/Neptune-Crypto/neptune-core/pull/554>

--- a/xnt-core/src/util_types/mutator_set/removal_record/absolute_index_set.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record/absolute_index_set.rs
@@ -130,6 +130,14 @@ impl AbsoluteIndexSet {
             .map(|x| u128::from(x).saturating_add(self.minimum))
     }
 
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = u128> + '_ {
+        let min = self.minimum;
+        self.distances
+            .iter()
+            .map(move |&d| min.saturating_add(u128::from(d)))
+    }
+
     /// Split the [`AbsoluteIndexSet`] into two parts, one for chunks in the
     /// inactive part of the Bloom filter and another one for chunks in the
     /// active part of the Bloom filter.

--- a/xnt-core/src/util_types/mutator_set/removal_record/chunk.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record/chunk.rs
@@ -63,6 +63,21 @@ impl Chunk {
         self.relative_indices.sort();
     }
 
+    /// Insert a batch of indices. Equivalent to calling [`Self::insert`] for
+    /// each of them, but sorts only once.
+    pub fn insert_many(&mut self, indices: &[u32]) {
+        for index in indices {
+            assert!(
+                *index < CHUNK_SIZE,
+                "index cannot exceed chunk size in `insert`. CHUNK_SIZE = {}, got index = {}",
+                CHUNK_SIZE,
+                index
+            );
+        }
+        self.relative_indices.extend_from_slice(indices);
+        self.relative_indices.sort();
+    }
+
     pub fn remove_once(&mut self, index: u32) {
         assert!(
             index < CHUNK_SIZE,

--- a/xnt-core/src/util_types/mutator_set/removal_record/removal_record_list.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record/removal_record_list.rs
@@ -280,10 +280,12 @@ impl RemovalRecordList {
     ///  - If the observed authentication path lengths is not sorted in
     ///    descending order (*i.e.*, largest first).
     ///  - If the observed authentication path lengths contains duplicates.
+    ///
+    /// Returns `None` if the estimate is not representable.
     fn estimate_num_leafs_aocl(
         observed_chunk_indices: &[u64],
         observed_authentication_path_lengths: &[usize],
-    ) -> u64 {
+    ) -> Option<u64> {
         let largest_observed_chunk_index =
             observed_chunk_indices.iter().copied().max().unwrap_or(0);
         let mut swbfi_leaf_count_estimate = largest_observed_chunk_index;
@@ -312,7 +314,9 @@ impl RemovalRecordList {
             }
         }
 
-        swbfi_leaf_count_estimate * u64::from(BATCH_SIZE) + 1
+        swbfi_leaf_count_estimate
+            .checked_mul(u64::from(BATCH_SIZE))?
+            .checked_add(1)
     }
 
     /// Compute a [`ChunkDictionary`], densely encoding all the data about
@@ -600,7 +604,8 @@ impl RemovalRecordList {
         let num_leafs_aocl = Self::estimate_num_leafs_aocl(
             &observed_chunk_indices,
             &tree_heights.iter().map(|u| *u as usize).rev().collect_vec(),
-        );
+        )
+        .ok_or(RemovalRecordListUnpackError::AbsoluteIndexTooBig)?;
 
         let removal_record_list = Self {
             index_sets,
@@ -689,7 +694,8 @@ impl RemovalRecordList {
         let num_leafs_aocl = RemovalRecordList::estimate_num_leafs_aocl(
             &observed_chunk_indices,
             &authentication_path_lengths,
-        );
+        )
+        .expect("locally derived removal records must have a representable AOCL leaf count");
 
         RemovalRecordList::from_removal_records(removal_records, num_leafs_aocl)
     }
@@ -1462,7 +1468,8 @@ mod tests {
         let estimate_num_leafs_aocl = RemovalRecordList::estimate_num_leafs_aocl(
             &chunk_indices,
             &authentication_path_lengths,
-        );
+        )
+        .unwrap();
 
         prop_assert!(estimate_num_leafs_aocl <= num_leafs_aocl);
     }
@@ -1490,7 +1497,8 @@ mod tests {
         let estimate_num_leafs_aocl = RemovalRecordList::estimate_num_leafs_aocl(
             &chunk_indices,
             &authentication_path_lengths,
-        );
+        )
+        .unwrap();
 
         // the estimate explains all authentication path lengths
         let num_leafs_swbfi = aocl_to_swbfi_leaf_counts(estimate_num_leafs_aocl);
@@ -1556,7 +1564,8 @@ mod tests {
         let estimate_num_leafs_aocl = RemovalRecordList::estimate_num_leafs_aocl(
             &chunk_indices,
             &authentication_path_lengths,
-        );
+        )
+        .unwrap();
 
         // the estimate explains all authentication path lengths
         let num_leafs_swbfi = aocl_to_swbfi_leaf_counts(estimate_num_leafs_aocl);
@@ -2229,6 +2238,23 @@ mod tests {
             // Ensure no crash, and that an error is returned.
             assert!(RemovalRecordList::try_unpack(removal_records).is_err());
         }
+
+        #[test]
+        fn try_unpack_rejects_indices_that_overflow_the_aocl_leaf_count_estimate() {
+            let removal_record = RemovalRecord {
+                absolute_indices: AbsoluteIndexSet::new_raw(1u128 << 74, [0; NUM_TRIALS as usize]),
+                target_chunks: ChunkDictionary::new(vec![(
+                    0,
+                    (MmrMembershipProof::new(vec![]), Chunk::empty_chunk()),
+                )]),
+            };
+
+            assert!(matches!(
+                RemovalRecordList::try_unpack(vec![removal_record]),
+                Err(RemovalRecordListUnpackError::AbsoluteIndexTooBig)
+            ));
+        }
+
 
         #[test]
         fn no_panic_on_mispaired_authentication_structures() {

--- a/xnt-core/src/util_types/mutator_set/removal_record/removal_record_list.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record/removal_record_list.rs
@@ -62,6 +62,8 @@ pub(crate) enum RemovalRecordListUnpackError {
     IllegalTreeHeight { tree_height: u64 },
     #[error("List of tree heights contains duplicates.")]
     DuplicateTreeHeights,
+    #[error("Incorrectly sorted tree heights.")]
+    IncorrectlySortedTreeHeights,
     #[error("removal records are mutually inconsistent: {0}")]
     Inconsistency(RemovalRecordListInconsistency),
 }
@@ -551,6 +553,8 @@ impl RemovalRecordList {
     fn decode_from_vec(
         removal_records: Vec<RemovalRecord>,
     ) -> Result<RemovalRecordList, RemovalRecordListUnpackError> {
+        // This function is not allowed to panic as it's run on untrusted
+        // input.
         let mut index_sets = vec![];
         let mut authentication_structures = vec![];
         let mut chunks = vec![];
@@ -562,6 +566,13 @@ impl RemovalRecordList {
                 removal_record.target_chunks.iter()
             {
                 if *tree_height < Self::ENCODING_TREE_HEIGHT_OFFSET {
+                    // Verify that tree heights are sorted correctly
+                    if let Some(previous) = tree_heights.last() {
+                        if *previous > *tree_height {
+                            return Err(RemovalRecordListUnpackError::IncorrectlySortedTreeHeights);
+                        }
+                    }
+
                     // use both authentication structure and chunk
                     tree_heights.push(*tree_height);
                     authentication_structures
@@ -654,6 +665,8 @@ impl RemovalRecordList {
 
     /// Decompress a [`Vec`] of [`RemovalRecord`]s as packed by [`Self::pack`].
     /// Returns an error if the packing is invalid.
+    ///
+    /// Never panics, so this function is safe to run on untrusted input.
     pub(crate) fn try_unpack(
         removal_records: Vec<RemovalRecord>,
     ) -> Result<Vec<RemovalRecord>, RemovalRecordListUnpackError> {
@@ -2314,6 +2327,31 @@ mod tests {
         }
 
         #[test]
+        fn no_panic_on_decending_tree_heights() {
+            let empty = Chunk::empty_chunk();
+            let removal_record = RemovalRecord {
+                absolute_indices: AbsoluteIndexSet::new_raw(0, [0; NUM_TRIALS as usize]),
+                target_chunks: ChunkDictionary {
+                    dictionary: vec![
+                        // Tree heights: [5,3] unique, descending
+                        (5, (MmrMembershipProof::new(vec![]), empty.clone())), // tree height 5
+                        (3, (MmrMembershipProof::new(vec![]), empty.clone())), // tree height 3
+                    ],
+                },
+            };
+
+            // Per the no-crash contract this must return Err, not panic.
+            let res = RemovalRecordList::try_unpack(vec![removal_record]);
+            assert!(
+                matches!(
+                    res,
+                    Err(RemovalRecordListUnpackError::IncorrectlySortedTreeHeights)
+                ),
+                "Must return expected error on incorrectly sorted tree heights"
+            );
+        }
+
+        #[test]
         fn too_many_chunks() {
             let absolute_indices_with_one_chunk_idx =
                 AbsoluteIndexSet::new_raw(0, [0; NUM_TRIALS as usize]);
@@ -2545,9 +2583,6 @@ mod tests {
             // Ensure no crash.
             let _ = RemovalRecordList::try_unpack(removal_records); // no crash
         }
-
-        #[proptest]
-        fn try_unpack_repeated_tree_height() {}
 
         #[proptest]
         fn removal_record_list_is_inconsistent_or_convert_to_vec_succeeds(

--- a/xnt-core/src/util_types/mutator_set/removal_record/removal_record_list.rs
+++ b/xnt-core/src/util_types/mutator_set/removal_record/removal_record_list.rs
@@ -511,6 +511,7 @@ impl RemovalRecordList {
         let expected_authentication_structure_lengths = all_peak_heights
             .into_iter()
             .zip(merkle_leaf_indices_by_tree)
+            .sorted_by_key(|&(peak_height, _)| peak_height)
             .map(|(ph, mlis)| {
                 MerkleTree::authentication_structure_node_indices(1_u64 << ph, &mlis)
                     .unwrap_or_else(|_| {
@@ -522,13 +523,11 @@ impl RemovalRecordList {
                     })
                     .len()
             })
-            .sorted()
             .collect_vec();
         let observed_authentication_structure_lengths = self
             .authentication_structures
             .iter()
             .map(|auth_str| auth_str.len())
-            .sorted()
             .collect_vec();
         if expected_authentication_structure_lengths != observed_authentication_structure_lengths {
             return Err(
@@ -2229,6 +2228,63 @@ mod tests {
 
             // Ensure no crash, and that an error is returned.
             assert!(RemovalRecordList::try_unpack(removal_records).is_err());
+        }
+
+        #[test]
+        fn no_panic_on_mispaired_authentication_structures() {
+            let num_aocl_leafs = 120;
+            let mut test_runner = TestRunner::deterministic();
+            let mut rng = rng();
+
+            // Find a set of removal records that spans two trees whose
+            // authentication structures have different lengths; only then can
+            // the structures be mispaired without changing the multiset.
+            let mut swapped = None;
+            for _ in 0..100 {
+                let item: Digest = rng.random();
+                let msa_and_records = MsaAndRecords::arbitrary_with((
+                    vec![(item, Digest::default(), Digest::default()); 2],
+                    num_aocl_leafs,
+                ))
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
+
+                let packed = RemovalRecordList::pack(msa_and_records.unpacked_removal_records());
+                let dictionary = &packed[0].target_chunks.dictionary;
+                let Some((i, j)) = (0..dictionary.len())
+                    .cartesian_product(0..dictionary.len())
+                    .find(|&(i, j)| {
+                        dictionary[i].1 .0.authentication_path.len()
+                            != dictionary[j].1 .0.authentication_path.len()
+                    })
+                else {
+                    continue;
+                };
+
+                let mut mispaired = packed.clone();
+                let dictionary = &mut mispaired[0].target_chunks.dictionary;
+                let structure_i = dictionary[i].1 .0.authentication_path.clone();
+                let structure_j = dictionary[j].1 .0.authentication_path.clone();
+                dictionary[i].1 .0.authentication_path = structure_j;
+                dictionary[j].1 .0.authentication_path = structure_i;
+                swapped = Some(mispaired);
+                break;
+            }
+
+            let mispaired = swapped.expect("must find two structures of differing lengths");
+
+            // Per the no-crash contract this must return Err, not panic.
+            let result = RemovalRecordList::try_unpack(mispaired);
+            assert!(
+                matches!(
+                    result,
+                    Err(RemovalRecordListUnpackError::Inconsistency(
+                        RemovalRecordListInconsistency::AuthenticationStructureLength { .. }
+                    ))
+                ),
+                "Must return expected error on mispaired authentication structures. Got: {result:?}"
+            );
         }
 
         #[test]

--- a/xnt-core/src/util_types/mutator_set/shared.rs
+++ b/xnt-core/src/util_types/mutator_set/shared.rs
@@ -6,6 +6,7 @@ use tasm_lib::prelude::Digest;
 use tasm_lib::prelude::Tip5;
 use tasm_lib::twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 
+use super::removal_record::chunk::Chunk;
 use super::removal_record::chunk_dictionary::ChunkDictionary;
 use super::removal_record::RemovalRecord;
 
@@ -127,9 +128,158 @@ pub fn get_batch_mutation_argument_for_removal_record(
     )
 }
 
+/// Given a batch of removal records, return a hashmap of
+/// {chunk_index => absolute_indices} with the indices of the entire batch
+/// put in the correct chunk buckets. Multiplicities are preserved.
+fn combined_chunkidx_to_indices_dict(removal_records: &[RemovalRecord]) -> HashMap<u64, Vec<u128>> {
+    let mut chunkidx_to_indices: HashMap<u64, Vec<u128>> = HashMap::new();
+    for removal_record in removal_records {
+        for (chunk_index, indices) in removal_record.get_chunkidx_to_indices_dict() {
+            chunkidx_to_indices
+                .entry(chunk_index)
+                .or_default()
+                .extend(indices);
+        }
+    }
+
+    chunkidx_to_indices
+}
+
+/// Shared implementation of
+/// [`get_batch_mutation_argument_for_removal_records`] and
+/// [`prepare_authenticated_batch_modification_for_removal_records_reversion`],
+/// parameterized over the chunk mutation: inserting the batch's indices
+/// (application) or removing them (reversion).
+///
+/// Iterates each chunk dictionary once and looks its entries up in the
+/// combined index map, rather than scanning all dictionaries per mutated
+/// chunk; the batches can be large in both dimensions.
+fn batch_mutation_argument_for_removal_records<F: Fn(&mut Chunk, &[u128])>(
+    removal_records: &[RemovalRecord],
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+    mutate_chunk: F,
+) -> (HashSet<usize>, Vec<(u64, MmrMembershipProof, Digest)>) {
+    let chunkidx_to_indices = combined_chunkidx_to_indices_dict(removal_records);
+
+    // chunk index -> (mmr mp, chunk hash)
+    let mut batch_modification_hash_map: HashMap<u64, (MmrMembershipProof, Digest)> =
+        HashMap::new();
+    // `mutated_chunk_dictionaries` records the indices into the
+    // input `chunk_dictionaries` slice that shows which elements
+    // contain modified chunks.
+    let mut mutated_chunk_dictionaries: HashSet<usize> = HashSet::new();
+    for (i, chunk_dictionary) in chunk_dictionaries.iter_mut().enumerate() {
+        for (chunk_index, (mmr_mp, chunk)) in chunk_dictionary.iter_mut() {
+            let Some(indices) = chunkidx_to_indices.get(chunk_index) else {
+                continue;
+            };
+            mutated_chunk_dictionaries.insert(i);
+            mutate_chunk(chunk, indices);
+
+            // Since all of the batch's indices have been applied to the
+            // chunk, the hash of the fully mutated chunk can be calculated
+            // now. Inserted into the mutation argument is the mutated chunk
+            // and its *old* (non-mutated) MMR membership proof.
+            if !batch_modification_hash_map.contains_key(chunk_index) {
+                batch_modification_hash_map
+                    .insert(*chunk_index, (mmr_mp.to_owned(), Tip5::hash(chunk)));
+            }
+        }
+    }
+
+    // For leafs that exist in no chunk dictionary, the authentication data is
+    // read from the removal records instead. Their chunk values are synced to
+    // the same state as the chunk dictionaries, so the mutation applies to
+    // the sourced chunks too. Indices whose chunk the removal records don't
+    // have either should be in the active part of the SWBF, where no leaf
+    // needs mutating.
+    if batch_modification_hash_map.len() < chunkidx_to_indices.len() {
+        let record_chunks: HashMap<u64, &(MmrMembershipProof, Chunk)> = removal_records
+            .iter()
+            .flat_map(|removal_record| removal_record.target_chunks.iter())
+            .map(|(chunk_index, authenticated_chunk)| (*chunk_index, authenticated_chunk))
+            .collect();
+        for (chunk_index, indices) in &chunkidx_to_indices {
+            if batch_modification_hash_map.contains_key(chunk_index) {
+                continue;
+            }
+            let Some((mp, chunk)) = record_chunks.get(chunk_index) else {
+                continue;
+            };
+            let mut target_chunk = chunk.to_owned();
+            mutate_chunk(&mut target_chunk, indices);
+
+            batch_modification_hash_map
+                .insert(*chunk_index, (mp.to_owned(), Tip5::hash(&target_chunk)));
+        }
+    }
+
+    (
+        mutated_chunk_dictionaries,
+        batch_modification_hash_map
+            .into_iter()
+            .map(|(i, (p, l))| (i, p, l))
+            .collect(),
+    )
+}
+
 /// Prepare a batch-modification with necessary authentication data
 /// to update the chunk dictionaries of mutator set membership proofs
-/// under *reversion* of a removal record.
+/// or removal records under application of a batch of removal records.
+///
+/// Like [`get_batch_mutation_argument_for_removal_record`], but handles the
+/// application of any number of removal records with a single mutation
+/// argument, i.e. a single batch-mutation of the MMR membership proofs. The
+/// combined mutation is well-defined because the chunk modifications of the
+/// individual applications commute: each only inserts indices into chunks.
+///
+/// The applied removal records must be synced to the same mutator-set state
+/// as the chunk dictionaries.
+pub fn get_batch_mutation_argument_for_removal_records(
+    removal_records: &[RemovalRecord],
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+) -> (HashSet<usize>, Vec<(u64, MmrMembershipProof, Digest)>) {
+    batch_mutation_argument_for_removal_records(removal_records, chunk_dictionaries, {
+        |chunk, indices| {
+            let relative_indices = indices
+                .iter()
+                .map(|index| (index % u128::from(CHUNK_SIZE)) as u32)
+                .collect_vec();
+            chunk.insert_many(&relative_indices);
+        }
+    })
+}
+
+/// Prepare a batch-modification with necessary authentication data
+/// to update the chunk dictionaries of mutator set membership proofs
+/// or removal records under *reversion* of a batch of removal records.
+///
+/// Like
+/// [`prepare_authenticated_batch_modification_for_removal_record_reversion`],
+/// but handles the reversion of any number of removal records with a single
+/// mutation argument, i.e. a single batch-mutation of the MMR membership
+/// proofs.
+///
+/// Unlike the one-record version, which takes the reverted record in its
+/// as-applied form, the reverted removal records here must be synced to the
+/// same mutator-set state as the chunk dictionaries — the state *after* the
+/// application of the entire batch, including themselves.
+pub fn prepare_authenticated_batch_modification_for_removal_records_reversion(
+    removal_records: &[RemovalRecord],
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+) -> (HashSet<usize>, Vec<(u64, MmrMembershipProof, Digest)>) {
+    batch_mutation_argument_for_removal_records(removal_records, chunk_dictionaries, {
+        |chunk, indices| {
+            for index in indices {
+                chunk.remove_once((index % u128::from(CHUNK_SIZE)) as u32);
+            }
+        }
+    })
+}
+
+/// Prepare a batch-modification with necessary authentication data
+/// to update the chunk dictionaries of mutator set membership proofs
+/// or removal records under *reversion* of a removal record.
 ///
 /// Parameters:
 ///  - `removal_record`: a reference to the removal record that is


### PR DESCRIPTION
# Port neptune-core v0.16.0 improvements

Ports 25 upstream fixes and features from neptune-core v0.16.0 into xnt-core, plus 9 fork-specific commits. Every change
was verified against a real baseline; the branch has been validated against the full live
mainnet chain and battle-tested on a mainnet node.

## Security

- **ProofCollection verification hardening** — closes the #936 zip-truncation hole where a
  transaction with fewer halting proofs than script hashes verified as valid (skipping all
  spend-authorization and value-conservation checks). Guarded in *both* of this fork's
  verify paths (`verify` and `verify_v2`).
- Reject ProofCollection-backed transactions with the merge bit set; reject bad
  ProofCollection transactions faster.
- **Remote-panic cluster fixed** (each remotely triggerable via peer messages): mispaired
  authentication structures, unchecked arithmetic in removal-record unpacking, duplicated
  chunk indices, future Bloom-filter indices, negative cum-pow difference, off-by-one in
  the activity split, incorrectly sorted tree heights.
- Bounded message decoding (8 MB announcement-ciphertext cap), oversized peer-list
  handling, bounded proof-upgrader job queue.
- RPC cookie file access restricted on unix; RPC membership-proof restoration now capped
  (1000 hard / 256 restricted) and chunked so the read lock is released every 16
  derivations — previously an unbounded, lock-holding endpoint.

## Mempool

- Reject transactions too big to ever be mined at admission (with `MERGE_HEADROOM = 5`
  slots reserved for the composer); same caps applied to the block transaction built by
  `mine_loop`, so our own composer cannot assemble an unminable block.
- Deduplicate "update" jobs across multiple new blocks.

## Performance

Mutator-set batching series (5 commits): batch removal-record maintenance, batched
`can_remove_all`, mutator-set update composition, and replacement of the archival-state
scratch-pad approach with functional composition.

`get_mutator_set_update_to_tip`, measured before/after on the same machine (result
asserted byte-identical on both sides):

| depth (blocks) | before | after |
|---|---|---|
| 1 | 5.6 ms | 3.4 ms |
| 10 | 46.3 ms | 22.4 ms |
| 20 | 81.6 ms | 35.1 ms |

## Proof upgrader

- A failed upgrade no longer starves every other candidate (failed transactions are
  skipped until the next block).
- A third-party merge that replaces our `Critical` transaction inherits its priority, so
  the mempool keeps maintaining the transaction that carries our funds.
- The gobbler reward is registered even when the upgrade completes unsynced (previously
  silently lost with off-chain fee notifications).
- Job with the highest upgrade incentive is selected; job queue is bounded.

## Node reliability

- **Archival state recovers on startup** after a non-graceful shutdown (block index ahead
  of block MMR / mutator set is replayed and repaired).
- Database `persist` is cancel-safe.
- **Sync-mode deadline is refreshed on canonical progress** — previously sync was
  abandoned a fixed 480 s after entry regardless of progress, wasting ~33 % of sync
  wall-clock and pushing catch-up onto a RAM-unbounded fork-reconciliation path
  (observed: 17 GB spike, node OOM-killed mid-apply). Verified live: 9 h of continuous
  mainnet sync with zero timeouts, vs one every ~12 min before.

## Fork-specific fixes

- **Premine**: the fork had dropped upstream's devnet-wallet allocation, leaving every
  test-network preminer unfunded. Restored for non-mainnet networks only; **mainnet's
  distribution and genesis are untouched** and the genesis hash is now pinned by a test.
  Note: this changes the genesis of test networks (testnet/regtest reset).
- Premine-dependent proof-upgrader tests migrated off `Network::Main` (first-ever green
  runs for those tests).
- `get_wallet_status` no longer panics on a monitored UTXO without membership proofs.

## Consensus impact

- **Technical softfork**: `can_remove_all` tightens removal-record validation (each record
  must clear its own unique Bloom-filter index). Strictly stricter — new nodes could
  reject a block old nodes accept, never the reverse. Upstream puts the probability of
  this ever firing at ~2^-160. **Validated against our chain: all 76,408 mainnet blocks
  (38,149 spending blocks, 172,191 removal records) replay clean under the new rules,
  with byte-exact mutator sets at every height, and the production-build genesis matches
  the live chain's exactly.**
- Test-network genesis changes (see premine fix). Mainnet genesis unchanged.
- Everything else is mempool/relay policy or node-local behavior.

## Live validation

Beyond the test suite (zero regressions vs baseline across all sweeps; ~10 previously
failing tests now pass):

- Fresh node built from this branch **synced the full mainnet chain from an old-binary
  node** (handshake, sync-challenge, batch download, full validation) and runs at tip.
- **Mainnet transaction lifecycle** exercised end-to-end: send → mempool → cross-version
  relay to an old node → proof upgrade → mined and confirmed (twice).
- Proof upgrading in production: 47+ successful foreign upgrades, gobbler rewards
  registered correctly.
- Multi-day uptime, zero panics.

## Upstream commits evaluated and rejected

- `4dbbd3b6` (skip per-block wallet MSMP restore): this fork's wallet has no on-demand
  proof restoration; taking it leaves the wallet reading balance 0 after every block.
- `0d9b31b8` (peer_loop lock fix): targets sync-loop code this fork does not have; our
  block path already validates without holding the lock.
- `437fa746` (merge after raise): deferred — entangled with consolidator tests and
  RegTest/lustration fixes that don't apply here; revisit with the consolidator.

## Deploy notes

- Ship **all three binaries together**: `xnt-core`, `xnt-cli`, and `triton-vm-prover`
  (the prover must live in the same directory as `xnt-core`).
- Mention the softfork in release notes; upgrade stricter nodes first.
- If running under pm2, set `kill_timeout` ≥ 30 s — the default 1.6 s is shorter than the
  database flush on shutdown and causes restart races.
